### PR TITLE
Added links to top-level captions in summary

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -3,7 +3,7 @@
 * [General Info](general-info/general-info.md)
 * [Getting Started](getting-started/getting-started.md)
 * [Build Instructions](build-instructions/build-instructions.md)
-* Release Notes
+* [Release Notes](release-notes/release-notes.md)
     * [Payara Server 4.1.144 Release Notes](release-notes/release-notes-144.md)
     * [Payara Server 4.1.151 Release Notes](release-notes/release-notes-151.md)
     * [Payara Server 4.1.152 Release Notes](release-notes/release-notes-152.md)
@@ -13,8 +13,8 @@
     * [Payara Server 4.1.1.161 Release Notes](release-notes/release-notes-161.md)
     * [Payara Server 4.1.1.161.1 Release Notes](release-notes/release-notes-161.1.md)
     * [Payara Server 4.1.1.162 Release Notes](release-notes/release-notes-162.md)
-* Core Documentation
-* Extended Documentation
+* [Core Documentation](documentation/core-documentation/core-documentation.md)
+* [Extended Documentation](documentation/extended-documentation/extended-documentation.md)
     * [Advanced JDBC](documentation/extended-documentation/advanced-jdbc/advanced-jdbc-configuration-and-diagnostics.md)
         * [Advanced Connection Pool Properties](documentation/extended-documentation/advanced-jdbc/advanced-jdbc-configuration-and-diagnostics.md)
         * [Log JDBC Calls](documentation/extended-documentation/advanced-jdbc/log-jdbc-calls.md)
@@ -26,5 +26,4 @@
     * [Health Check Service](documentation/extended-documentation/health-check-service/health-check-service.md)
         * [Asadmin Commands](documentation/extended-documentation/health-check-service/asadmin-commands.md)
         * [Configuration](documentation/extended-documentation/health-check-service/configuration.md)
-* Payara Micro Documentation
-    * [Payara Micro Overview](documentation/payara-micro/payara-micro.md)
+* [Payara Micro Documentation](documentation/payara-micro/payara-micro.md)

--- a/documentation/core-documentation/core-documentation.md
+++ b/documentation/core-documentation/core-documentation.md
@@ -1,0 +1,7 @@
+# Core Documentation
+
+Documentation of core features, shared with GlassFish Server 4 Open Source Edition.
+
+## References
+
+ - [GlassFish Server 4 Open Source Edition documentation](https://glassfish.java.net/documentation.html)

--- a/documentation/extended-documentation/extended-documentation.md
+++ b/documentation/extended-documentation/extended-documentation.md
@@ -1,0 +1,3 @@
+# Extended Documentation
+
+Documentation of all the features added on top of GlassFish Server 4 Open Source Edition.

--- a/release-notes/release-notes.md
+++ b/release-notes/release-notes.md
@@ -1,0 +1,3 @@
+# Release notes
+
+Detailed information about features and fixes in every release.


### PR DESCRIPTION
Without the links, generated PDF docs messed up table of contents.

Here is a preview of the gitbook: https://ondrejm.gitbooks.io/payara-server-documentation-fork/content/v/3c949945cd5f0b87800a2dbe9f6b166fe6af791c/

Here is a link to download a PDF version: https://www.gitbook.com/download/pdf/book/ondrejm/payara-server-documentation-fork/v/3c949945cd5f0b87800a2dbe9f6b166fe6af791c