### PR TITLE
PYSVC-211 + Classloading documentation revamped

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -69,7 +69,7 @@
     * [Disabling Phone Home](documentation/extended-documentation/phone-home/disabling-phone-home.md)
   * [System Properties](documentation/extended-documentation/system-properties.md)
   * [Production Ready Domain](documentation/extended-documentation/production-ready-domain.md)
-  * [Classloading](documentation/extended-documentation/classloading.md)
+  * [Enhanced Classloading](documentation/extended-documentation/classloading.md)
   * [Default Thread Pool Size](documentation/extended-documentation/default-thread-pool-size.md)
   * [Public API](documentation/extended-documentation/app-deployment/public-api.md)
 * [User Guides](documentation/user-guides/user-guides.md)
@@ -130,3 +130,4 @@
   * [Payara Server 4.1.152 Release Notes](release-notes/release-notes-152.md)
   * [Payara Server 4.1.151 Release Notes](release-notes/release-notes-151.md)
   * [Payara Server 4.1.144 Release Notes](release-notes/release-notes-144.md)
+

--- a/documentation/extended-documentation/app-deployment/deployment-descriptors.md
+++ b/documentation/extended-documentation/app-deployment/deployment-descriptors.md
@@ -10,6 +10,8 @@ Payara Server supports additional configuration settings by using the Glassfish 
      - enable-implicit-cdi
      - default-role-mapping (_property_)
      - whitelist-package
+     - scanning-exclude
+     - scanning-include
 
 ## glassfish-web.xml
 
@@ -17,6 +19,8 @@ Payara Server supports additional configuration settings by using the Glassfish 
     - container-initialized-enabled
     - default-role-mapping (_property_)
     - whitelist-package
+    - scanning-exclude
+    - scanning-include
 
 ## glassfish-ejb-jar.xml
 

--- a/documentation/extended-documentation/app-deployment/deployment-descriptors.md
+++ b/documentation/extended-documentation/app-deployment/deployment-descriptors.md
@@ -9,12 +9,14 @@ Payara Server supports additional configuration settings by using the Glassfish 
      - classloading-delegate
      - enable-implicit-cdi
      - default-role-mapping (_property_)
+     - whitelist-package
 
 ## glassfish-web.xml
 
  - glassfish-web-app
     - container-initialized-enabled
     - default-role-mapping (_property_)
+    - whitelist-package
 
 ## glassfish-ejb-jar.xml
 

--- a/documentation/extended-documentation/app-deployment/descriptor-elements.md
+++ b/documentation/extended-documentation/app-deployment/descriptor-elements.md
@@ -4,8 +4,15 @@ This page is a reference for extra elements added to either the `glassfish-appli
 
 ### `classloading-delegate`
 
-With this option, the libraries included in the EAR assembly will override libraries included in Payara Server distribution. 
-For more information about how Payara Server loads the required classes and libraries, see the [Classloading](../classloading.md) section.
+With this option its possible to enable/disable classloading delegation. This allows deployed application to use libraries included on them, overriding the version included on the server. 
+
+For more information about how class delegation can be configured on Payara Server, see the [Enhanced Classloading](/documentation/extended-documentation/classloading.md) section.
+
+### `whitelist-package`
+
+Used to whitelist packages on **extreme classloading isolation**. Whitelisted packages are taken into account by the server when scanning libraries included on the server.
+
+For more information about extreme classloading isolation works on Payara Server, see the [Enhanced Classloading](/documentation/extended-documentation/classloading.md) section.
 
 ### `enable-implicit-cdi`
 

--- a/documentation/extended-documentation/app-deployment/descriptor-elements.md
+++ b/documentation/extended-documentation/app-deployment/descriptor-elements.md
@@ -4,7 +4,7 @@ This page is a reference for extra elements added to either the `glassfish-appli
 
 ### `classloading-delegate`
 
-With this option its possible to enable/disable classloading delegation. This allows deployed application to use libraries included on them, overriding the versions included on the server. 
+With this option its possible to enable/disable classloading delegation. This allows deployed application to use libraries included on them, overriding the versions included on the server.
 
 For more information about how class delegation can be configured on Payara Server, see the [Enhanced Classloading](/documentation/extended-documentation/classloading.md) section.
 
@@ -12,7 +12,7 @@ For more information about how class delegation can be configured on Payara Serv
 
 Used to whitelist packages on **extreme classloading isolation**. Whitelisted packages are taken into account by the server when scanning libraries included on the server.
 
-For more information about extreme classloading isolation works on Payara Server, see the [Enhanced Classloading](/documentation/extended-documentation/classloading.md) section.
+For more information about how extreme classloading isolation works on Payara Server, see the [Enhanced Classloading](/documentation/extended-documentation/classloading.md) section.
 
 ### `enable-implicit-cdi`
 
@@ -29,11 +29,12 @@ If implicit CDI scanning causes problems for an EAR assembly, the value `false` 
 ```
 
 **Note**:  
-When implicit CDI is controlled by using either the `enable-implicit-cdi` property in the `glassfish-application.xml` or the attribute `bean-discovery-mode="none"` from the `beans.xml` file in a WAR, the admin console checkbox ***is ignored***.
+When implicit CDI is controlled by using either the `enable-implicit-cdi` property in the `glassfish-application.xml` or the attribute `bean-discovery-mode="none"` from the `beans.xml` file in a WAR, the admin console checkbox _**is ignored**_.
 
 The default behaviour of the admin console is for the "Implicit CDI" checkbox to be enabled, but this will **not** override the application configuration.
 
 ### `scanning-exclude` and `scanning-include`
+
 Modern WAR and EAR files very often include a number of 3rd party JARs. In situations where some JARs require CDI scanning and others may break if scanned, these can now be explicitly included or excluded from scanning.
 
 Both the `glassfish-application.xml` and the `glassfish-web.xml` files support the following directives:
@@ -77,3 +78,4 @@ Except it's effect will only limit itself to the application instead of all appl
 The default value of this property is `false`. This property can be set in the `glassfish-web.xml`, `glassfish-ejb-jar.xml` and `glassfish-application.xml` deployment descriptors.
 
 In an EAR assembly, only the property set in the `glassfish-application.xml` will take effect and any set in the `glassfish-web.xml` and `glassfish-ejb-jar.xml` will be ignored. Setting this configuration property in any of these files will always take precedence over any setting configured on the server.
+

--- a/documentation/extended-documentation/app-deployment/descriptor-elements.md
+++ b/documentation/extended-documentation/app-deployment/descriptor-elements.md
@@ -1,7 +1,9 @@
 # Elements of the Deployment Descriptor Files
+
 This page is a reference for extra elements added to either the `glassfish-application.xml` or the `glassfish-web.xml` files in Payara Server.
 
 ### `classloading-delegate`
+
 With this option, the libraries included in the EAR assembly will override libraries included in Payara Server distribution. 
 For more information about how Payara Server loads the required classes and libraries, see the [Classloading](../classloading.md) section.
 

--- a/documentation/extended-documentation/app-deployment/descriptor-elements.md
+++ b/documentation/extended-documentation/app-deployment/descriptor-elements.md
@@ -4,7 +4,7 @@ This page is a reference for extra elements added to either the `glassfish-appli
 
 ### `classloading-delegate`
 
-With this option its possible to enable/disable classloading delegation. This allows deployed application to use libraries included on them, overriding the version included on the server. 
+With this option its possible to enable/disable classloading delegation. This allows deployed application to use libraries included on them, overriding the versions included on the server. 
 
 For more information about how class delegation can be configured on Payara Server, see the [Enhanced Classloading](/documentation/extended-documentation/classloading.md) section.
 

--- a/documentation/extended-documentation/classloading.md
+++ b/documentation/extended-documentation/classloading.md
@@ -4,18 +4,23 @@ This page covers how to use the Enhanced Class and Library Loading functionality
 
 # Default Class and Library Loading
 
-Payara Server comes included with many standard Java libraries and packages, for example Google Guava, Jackson, Logback and others.
+Payara Server comes included with many standard Java libraries and packages, for example **Google Guava**, **Jackson**, **Logback** and others.
 
-By default, due to the way standard classloading works, if a class is found in one of Payara Server included libraries, it will be the one used for an specific application, even if the application itself includes a different version of the same library.
+By default, due to the way standard classloading works; if a class is found in one of the library or modules that are included within Payara Server, it will be the one used for an specific application, even if the application itself includes a different version of the same library.
 
-Possible issues with default behavior
-In some cases, application developer will want to include a different version of the libraries that are already included in Payara.
+## Possible issues with default behavior
+
+In some cases, application developers will want to include different version of the libraries that are already included in Payara. Here are some of the most common use cases:
+
+1. 
+
 A common case is a later version of Guava or Jackson.  Another case is to include older versions of these packages for compatibility.
 Unfortunately, due to the default class loading behavior, this will not be possible, and Payara-included libraries will take precedence.
 
 # Solutions to the Class Loading issue
 
 # 4.1 Globally override Payara-included libraries
+
 You can set the system property `fish.payara.classloading.delegate` to `false`.
 This way, any library that is included by the application developer will override the one that's included in Payara.
 Class Loading is accomplished in the following order:
@@ -36,7 +41,7 @@ This option is also provided by GlassFish Server 4 Open Source Edition.
 For EAR files, you can include `<classloading-delegate>false</classloading-delegate>` in your `META-INF/glassfish-application.xml` file.
 With this option, your EAR-included libraries will override Payara-included libraries.
 
-# 4.4 Payara domain
+# 4.4 Payara Domain
 The only way to enable libraries in the _${Domain}_/lib to override Payara-included libraries ( _${Product-Root}_/modules )
 is to set the system property `fish.payara.classloading.delegate` to `false` as described above.
 

--- a/documentation/extended-documentation/classloading.md
+++ b/documentation/extended-documentation/classloading.md
@@ -19,7 +19,7 @@ Unfortunately, due to the default class loading behavior, this will not be possi
 
 # Solutions to the Class Loading issue
 
-# Globally override Payara-included libraries
+## Globally override Payara-included libraries
 
 You can set the system property `fish.payara.classloading.delegate` to `false`.
 This way, any library that is included by the application developer will override the one that's included in Payara.
@@ -32,22 +32,39 @@ Class Loading is accomplished in the following order:
 
 This is a Payara-specific feature
 
-# WAR Files
+## WAR Files
+
 For WAR files, you can include `<class-loader delegate="false"/>` in your `WEB-INF/glassfish-web.xml`. 
 With this option, your `WEB-INF/lib/xxx.jar` libraries will take precedence over Payara-included libraries.
 This option is also provided by GlassFish Server 4 Open Source Edition.
 
-# EAR Files
+## EAR Files
+
 For EAR files, you can include `<classloading-delegate>false</classloading-delegate>` in your `META-INF/glassfish-application.xml` file.
 With this option, your EAR-included libraries will override Payara-included libraries.
 
 # Payara Domain
-The only way to enable libraries in the _${Domain}_/lib to override Payara-included libraries ( _${Product-Root}_/modules )
-is to set the system property `fish.payara.classloading.delegate` to `false` as described above.
+
+The only way to enable libraries in the _${Domain}_/lib to override Payara-included libraries ( _${Product-Root}_/modules) is to set the system property `fish.payara.classloading.delegate` to `false` as described above.
 
 # Extreme Classloading Isolation
 
-# Conclusion and Recommendations
-We recommend that you set the system property `fish.payara.classloading.delegate` to `false` as this behavior is the desired behavior
-for most cases.  The reason this is not the default out-of-the-box is because Payara wants to keep drop-in replacement compatibility
-with GlassFish.
+Starting from release _4.1.1.171_, it's possible to configure a extreme isolation level on the classloading mechanism for applications deployed to Payara Server. With this extreme isolation behavior, a deployed application can force the server to load only classes that belong to **whitelisted packages** defined on its deployment descriptors. 
+
+To configure whitelist packaging you can use the `<whitelist-package>` element on the _glassfish-web.xml_ (WAR artifacts) or the _glassfish-application.xml_ (EAR artifacts). This element can be included multiple times to whitelist multiple packages. Here is an example of whitelisting both the **Google Guava** and **Jackson** packages for a web application:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app error-url="">
+  ...
+  <class-loader delegate="false"/>
+  <whitelist-package>com.google.guava</whitelist-package>
+  <whitelist-package>com.fasterxml.jackson</whitelist-package>
+</glassfish-web-app>
+```
+
+The whitelist syntax is simple: Define the name of the package that is going to be whitelisted. For example writing `com.google` would whiltelist all Google libraries included with the server, while `com.google.guava` would only whitelist the Google Guava library.
+
+To enable this extreme isolation behavior, at least one `whitelist-package` must be defined in the appropriate descriptor. 
+

--- a/documentation/extended-documentation/classloading.md
+++ b/documentation/extended-documentation/classloading.md
@@ -1,25 +1,19 @@
-# 1. Classloading 
+# Enhanced Classloading 
 
 This page covers how to use the Enhanced Class and Library Loading functionality introduced on _Payara 4.1.1.162_.  
 
-# 2. Documentation Conventions
-_${Product-Root}_ - This is the root of the Payara server directory, referring to where you have Payara installed.  
-_${Domain}_ - This refers to the name of your Payara domain.  
-_${Target}_ - This refers to the name of an instance or cluster.  
-`...` - Denotes a skipping of unrelated code that would be present in the actual file or program.  
-_${Cluster-Config}_ - This refers to the name of a cluster configuration.
+# Default Class and Library Loading
 
-# 3. Default Class and Library Loading
-Payara server comes included with many Java libraries and packages, for example Google Guava, Jackson, Logback and others.
-By default, due to the way Java Class Loading works, if a class is found in one of Payara-included libraries, it will be the one
-used in your application, even if you include a different version of the same library in your application package.
+Payara Server comes included with many standard Java libraries and packages, for example Google Guava, Jackson, Logback and others.
 
-# 3.1 Possible issues with default behavior
+By default, due to the way standard classloading works, if a class is found in one of Payara Server included libraries, it will be the one used for an specific application, even if the application itself includes a different version of the same library.
+
+Possible issues with default behavior
 In some cases, application developer will want to include a different version of the libraries that are already included in Payara.
 A common case is a later version of Guava or Jackson.  Another case is to include older versions of these packages for compatibility.
 Unfortunately, due to the default class loading behavior, this will not be possible, and Payara-included libraries will take precedence.
 
-# 4 Solutions to the Class Loading issue
+# Solutions to the Class Loading issue
 
 # 4.1 Globally override Payara-included libraries
 You can set the system property `fish.payara.classloading.delegate` to `false`.

--- a/documentation/extended-documentation/classloading.md
+++ b/documentation/extended-documentation/classloading.md
@@ -1,10 +1,10 @@
 # Enhanced Classloading 
 
-This page covers the Enhanced classloading functionality introduced on _Payara 4.1.1.162_.  
+This page covers the enhanced classloading functionality introduced on _Payara 4.1.1.162_.  
 
 # Default Class and Library Loading
 
-Payara Server has included many standard Java libraries and packages, for example **Google Guava**, **Jackson**, **Logback** and others. These libraries are located on the _${Product-Root}/modules_ directory.
+Payara Server has included many standard Java libraries and packages, for example **Google Guava**, **Jackson**, **Logback** and others to use . These libraries are located on the _${Product-Root}/modules_ directory.
 
 The default classloading mechanism of Payara Server Works like this: When loading classes that belong to a library or framework that is included in the server, the server **will always** load those classes even if the application itself includes different versions.
 

--- a/documentation/extended-documentation/classloading.md
+++ b/documentation/extended-documentation/classloading.md
@@ -1,6 +1,6 @@
-# Enhanced Classloading 
+# Enhanced Classloading
 
-This page covers the enhanced classloading functionality introduced on _Payara 4.1.1.162_.  
+This page covers the enhanced classloading functionality introduced on _Payara 4.1.1.162_.
 
 # Default Class and Library Loading
 
@@ -17,26 +17,26 @@ Unfortunately, due to the way the default classloading works, this will not be p
 
 # Disable Classloading delegation
 
-In order for the server's classloader to load classes from libraries of different versions to the ones shipped with it, it's possible to disable the **default classloader delegation**. It can be altered to allow the server to load classes in the following order:
+In order for the server's classloader to load classes from libraries of different versions to the ones shipped with it, it's possible to disable the **default classloader delegation**. It can be altered to allow the server to load classes from libraries located at different sources in the following order:
 
-* First, libraries on WAR applications (included on _WEB-INF/lib_)
-* Then, libraries on EAR applications (included on _/lib_)
-* Then, libraries from the domain (located at _${Domain}/lib_)
-* Finally, libraries from the server (located at _${Product-Root}/modules_)
+* First, libraries on WAR applications \(included on _WEB-INF/lib_\)
+* Then, libraries on EAR applications \(included on _/lib_\)
+* Then, libraries from the domain \(located at _${Domain}/lib_\)
+* Finally, libraries from the server \(located at _${Product-Root}/modules_\)
 
 ## Disable Classloading delegation globally
 
-To disable classloading delegation globally, you can set the system property `fish.payara.classloading.delegate` to `false`. This way, any library that is included on deployed applications will override the ones that are included in the server. 
+To disable classloading delegation globally, you can set the system property `fish.payara.classloading.delegate` to `false`. This way, any library that is included on deployed applications will override the ones that are included in the server.
 
-Libraries included at the domain level (_${Domain}/lib_) will take precedence over the libraries included at the server. 
+Libraries included at the domain level \(_${Domain}/lib_\) will take precedence over the libraries included at the server.
 
 ## Disable Classloading delegation locally
 
-It's possible to disable classloading delegation directly at the application level. This can be done for both WAR and EAR applications. 
+It's possible to disable classloading delegation directly at the application level. This can be done for both WAR and EAR applications.
 
 ### On WAR Applications
 
-For **WAR** applications, you can include `<class-loader delegate="false"/>` element in the `glassfish-web.xml` deployment descriptor. Here's an example: 
+For **WAR** applications, you can include `<class-loader delegate="false"/>` element in the `glassfish-web.xml` deployment descriptor. Here's an example:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -54,7 +54,7 @@ With this, all libraries included on the `WEB-INF/lib/` directory will take prec
 
 ### On EAR Applications
 
-For **EAR** applications, you can include the `<classloading-delegate>false</classloading-delegate>` element in the `glassfish-application.xml` deployment descriptor. Here is an example: 
+For **EAR** applications, you can include the `<classloading-delegate>false</classloading-delegate>` element in the `glassfish-application.xml` deployment descriptor. Here is an example:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -70,9 +70,9 @@ With this, all libraries included on the EAR's `lib/` directory will take preced
 
 # Extreme Classloading Isolation
 
-Starting from release _4.1.1.171_, it's possible to configure an extreme isolation level on the classloading delegation for deployed applications. With this extreme isolation behavior, a deployed application can force the server to load only classes that belong to **whitelisted packages** defined on its deployment descriptors. 
+Starting from release _4.1.1.171_, it's possible to configure an extreme isolation level on the classloading delegation for deployed applications. With this extreme isolation behavior, a deployed application can force the server to load only classes that belong to **whitelisted packages** defined on its deployment descriptors.
 
-To configure whitelist packaging you can use the `<whitelist-package>` element on the _glassfish-web.xml_ (WAR artifacts) or the _glassfish-application.xml_ (EAR artifacts). This element can be included multiple times to whitelist multiple packages. Here is an example of whitelisting both the **Google Guava** and **Jackson** packages for a WAR application:
+To configure whitelist packaging you can use the `<whitelist-package>` element on the _glassfish-web.xml_ \(WAR artifacts\) or the _glassfish-application.xml_ \(EAR artifacts\). This element can be included multiple times to whitelist multiple packages. Here is an example of whitelisting both the **Google Guava** and **Jackson** packages for a WAR application:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/documentation/extended-documentation/classloading.md
+++ b/documentation/extended-documentation/classloading.md
@@ -19,7 +19,7 @@ Unfortunately, due to the default class loading behavior, this will not be possi
 
 # Solutions to the Class Loading issue
 
-# 4.1 Globally override Payara-included libraries
+# Globally override Payara-included libraries
 
 You can set the system property `fish.payara.classloading.delegate` to `false`.
 This way, any library that is included by the application developer will override the one that's included in Payara.
@@ -32,20 +32,22 @@ Class Loading is accomplished in the following order:
 
 This is a Payara-specific feature
 
-# 4.2 WAR Files
+# WAR Files
 For WAR files, you can include `<class-loader delegate="false"/>` in your `WEB-INF/glassfish-web.xml`. 
 With this option, your `WEB-INF/lib/xxx.jar` libraries will take precedence over Payara-included libraries.
 This option is also provided by GlassFish Server 4 Open Source Edition.
 
-# 4.3 EAR Files
+# EAR Files
 For EAR files, you can include `<classloading-delegate>false</classloading-delegate>` in your `META-INF/glassfish-application.xml` file.
 With this option, your EAR-included libraries will override Payara-included libraries.
 
-# 4.4 Payara Domain
+# Payara Domain
 The only way to enable libraries in the _${Domain}_/lib to override Payara-included libraries ( _${Product-Root}_/modules )
 is to set the system property `fish.payara.classloading.delegate` to `false` as described above.
 
-# 5. Conclusion and Recommendations
+# Extreme Classloading Isolation
+
+# Conclusion and Recommendations
 We recommend that you set the system property `fish.payara.classloading.delegate` to `false` as this behavior is the desired behavior
 for most cases.  The reason this is not the default out-of-the-box is because Payara wants to keep drop-in replacement compatibility
 with GlassFish.

--- a/documentation/extended-documentation/classloading.md
+++ b/documentation/extended-documentation/classloading.md
@@ -1,17 +1,6 @@
-# Contents
-* [1. Overview](#1-overview)
-* [2. Documentation Conventions](#2-documentation-conventions)
-* [3. Default Class and Library Loading](#3-default-class-and-library-loading)
-  * [3.1 Possible issues with default behavior](#31-possible-issues-with-default-behavior)
-* [4. Solutions to the Class Loading issue](#4-solutions-to-the-class-loading-issue)
-  * [4.1 Globally override Payara-included libraries](#41-globally-override-payara-included-libraries)
-  * [4.2 WAR Files](#42-war-files)
-  * [4.3 EAR Files](#43-ear-files)
-  * [4.4 Payara domain](#44-payara-domain)
-* [5. Conclusion and Recommendations](#5-conclusion-and-recommendations)
+# 1. Classloading 
 
-# 1. Overview
-This page covers how to use the Enhanced Class and Library Loading functionality in Payara 4.1.1.162.  
+This page covers how to use the Enhanced Class and Library Loading functionality introduced on _Payara 4.1.1.162_.  
 
 # 2. Documentation Conventions
 _${Product-Root}_ - This is the root of the Payara server directory, referring to where you have Payara installed.  


### PR DESCRIPTION
Implemented documentation on the extreme classloading isolation feature introduced on 171. Also revamped the class loading documentation with the following changes:

* Renamed the article page to **Enhanced Classloading** to denote that there are present improvements into Payara Server when talking about classloading behaviours.
* Removed the internal TOC, not needed.
* Changed and restructured the article to reflect more a technical documentation on the features. The previous style of the article was more of a set of recommendations. 
* Introduced the term **classloading delegation** to make it more consistent with the actual feature built in Payara/GlassFish.