### PR TITLE
PYSVC-460 update health check svc

### DIFF
--- a/documentation/extended-documentation/health-check-service/asadmin-commands.adoc
+++ b/documentation/extended-documentation/health-check-service/asadmin-commands.adoc
@@ -1,5 +1,5 @@
 [[healthcheck-service]]
-= Healthcheck Service Asadmin Command Reference
+= Health Check Service Asadmin Command Reference
 
 [[healthcheck-configure]]
 == `healthcheck-configure`
@@ -8,15 +8,14 @@
 `asadmin> healthcheck-configure --enabled=true|false --dynamic=true|false --historicaltraceenabled --historicaltracestoresize=20`
 
 *Aim*::
-Enables or disables the health check service. The command updates
+Enables or disables the Health Check Service. The command updates
 the `domain.xml` with the provided configuration but does not apply
-changes directly to the working service by default. It can also store a
-given number of historical health checks.
+changes directly to the working service by default. It can also store a given number of historical health checks.
 
 [[command-options]]
 === Command Options
 
-[cols=",,,,",options="header",]
+[cols="2,1,1,1,1",options="header",]
 |=======================================================================
 |Option |Type |Description |Default |Mandatory
 |`--target` |String |The instance or cluster that will enable or disable
@@ -46,6 +45,8 @@ asadmin > healthcheck-configure
     --historicaltraceenabled
     --historicaltracestoresize=20
 ----
+
+NOTE: In order to get notifications from the Health Check Service, it's necessary to enable the Health Check Service together with at least one of its services and at least one of the link:../notification-service/notifiers.adoc[notifiers] in the Notification Service.
 
 [[healthcheck-list-services]]
 == `healthcheck-list-services`

--- a/documentation/extended-documentation/health-check-service/health-check-service.adoc
+++ b/documentation/extended-documentation/health-check-service/health-check-service.adoc
@@ -20,7 +20,7 @@ notification is sent to the Notification Service. Notifications can be then sent
 This allows operations teams to rapidly detect problems or work out what happened after these
 problems have occurred. 
 
-If the link:../notification-service/notifiers/log-notifier.adoc[Log] Notifier is enabled, such events will be presented in the server's log file like in the following sample:
+If the link:../notification-service/notifiers/log-notifier.adoc[Log Notifier] is enabled, such events will be presented in the server's log file like in the following sample:
 
 [source, log]
 ----

--- a/documentation/extended-documentation/health-check-service/health-check-service.adoc
+++ b/documentation/extended-documentation/health-check-service/health-check-service.adoc
@@ -15,11 +15,12 @@ When enabled it periodically checks the following performance metrics:
 
 If there is a problem with any of these metrics and they exceed a
 configurable threshold then a `GOOD`, `WARNING` or `CRITICAL` event
-message is logged to the server log file.
+notification is sent to the Notification Service. Notifications can be then sent to one or more Notifiers, e.g. a log file.
 
 This allows operations teams to rapidly detect problems or work out what happened after these
-problems have occurred. Such events will be presented like in the following
-sample:
+problems have occurred. 
+
+If the link:../notification-service/notifiers/log-notifier.adoc[Log] Notifier is enabled, such events will be presented in the server's log file like in the following sample:
 
 [source, log]
 ----


### PR DESCRIPTION
The docs are out of date - they expect that Health Check notifications go directly to the log file. In recent versions, they are routed to the Notification Service, which can send them to the log file.