### PR TITLE
Basic admonition icons

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,6 +1,7 @@
 {
     "plugins": [
         "expandable-chapters",
+        "asciidoc-admonition-icons",
         "versions"
         ],
 


### PR DESCRIPTION
Adds a plugin that turns admonition captions like WARNING or NOTE into icons, like :warning: and :information_source: 

Preview: https://ondrejm.gitbooks.io/payara-server-documentation-fork/content/v/admonition-icons/documentation/payara-micro/adding-jars.html