### PR TITLE
Fixes for multiple articles in preparation for 174 doc release

### DIFF
--- a/documentation/extended-documentation/hazelcast/asadmin.adoc
+++ b/documentation/extended-documentation/hazelcast/asadmin.adoc
@@ -3,6 +3,7 @@
 
 The following is a list of the administration commands used to configure Hazelcast.
 
+[[set-hazelcast-configuration]]
 == `set-hazelcast-configuration`
 
 _Since Payara Server 4.1.151_
@@ -15,6 +16,7 @@ Enables Hazelcast, which is disabled by default, as well as allowing
 configuration. This command requires the admin server to be running on port
 4848, unless specified otherwise.
 
+[[command-options]]
 === Command Options
 
 [cols=(,,,,),options="header"]
@@ -86,6 +88,7 @@ feature to work correctly.|_false_|No
 `-?` ||Displays the help menu.|_false_|No
 |====
 
+[[example]]
 === Example
 
 [source, shell]
@@ -93,6 +96,7 @@ feature to work correctly.|_false_|No
 asadmin> set-hazelcast-configuration --enabled=true --hostawarepartitioning=true --clustername=Cluster-1 --clusterpassword=Cluster1 --lite
 ----
 
+[[create-hazelcast-instance]]
 == `create-hazelcast-instance`
 
 _Since Payara Server 4.1.2.172_
@@ -103,6 +107,7 @@ _Since Payara Server 4.1.2.172_
 *Aim*::
 Creates a new Payara Server instance with Hazelcast and the persistence types.
 
+[[command-options-1]]
 === Command Options
 
 [cols=(,,,,),options="header"]
@@ -201,6 +206,7 @@ persistence.|_True_|No
 
 |====
 
+[[example-1]]
 === Example
 
 [source, shell]
@@ -208,6 +214,7 @@ persistence.|_True_|No
 asadmin> create-hazelcast-instance --webpersistence=false --lite instance2
 ----
 
+[[get-hazelcast-configuration]]
 == `get-hazelcast-configuration`
 
 _Since Payara Server 4.1.151_
@@ -218,6 +225,7 @@ Return the current Hazelcast configuration.
 *Usage*::
 `asadmin> get-hazelcast-configuration`
 
+[[command-options-2]]
 === Command Options
 
 [cols=(,,,,),options="header"]
@@ -229,6 +237,7 @@ Return the current Hazelcast configuration.
 `-?`||Displays the help menu|_fal
 |====
 
+[[example-2]]
 === Example
 
 [source, shell]
@@ -238,6 +247,7 @@ Configuration File    Enabled  Start Port  MulticastGroup  MulticastPort  JNDINa
 hazelcast-config.xml  true     5900        224.2.2.3       54327          payara/Hazelcast    false        clustername   password          XXXX-XXXX-XXXX-XXXX  false
 ----
 
+[[list-hazelcast-cluster-members]]
 == `list-hazelcast-cluster-members`
 
 _Since Payara Server 4.1.1.164_
@@ -249,6 +259,7 @@ extra properties.
 *Usage*::
 `asadmin> list-hazelcast-cluster-members`
 
+[[command-options-3]]
 === Command Options
 
 [cols=(,,,,),options="header"]
@@ -259,6 +270,7 @@ extra properties.
 `-?`||Displays the help menu|_false_
 |====
 
+[[example-3]]
 === Example
 
 [source, shell]
@@ -268,6 +280,7 @@ Instance Name  Instance Group  Instance Type  Host Name  HTTP Ports  HTTPS Ports
 server         server-config   DAS            127.0.1.1  8080        8181         4848        5901            false        __admingui
 ----
 
+[[list-hazelcast-members]]
 == `list-hazelcast-members`
 
 _Since Payara Server 4.1.151_
@@ -278,6 +291,7 @@ List the hazelcast members as a targetable array.
 *Usage*::
 `asadmin> list-hazelcast-members`
 
+[[command-options-4]]
 === Command Options
 
 [cols=(,,,,),options="header"]
@@ -289,6 +303,7 @@ cluster.|`server`|No
 `-?`||Displays the help menu|_false_
 |====
 
+[[example-4]]
 === Example
 
 [source, shell]
@@ -297,6 +312,7 @@ asadmin> list-hazelcast-members
 \{ server-/127.0.1.1:5901-this \}
 ----
 
+[[restart-hazelcast]]
 == `restart-hazelcast`
 
 _Since Payara Server 4.1.151_
@@ -307,6 +323,7 @@ Restarts Hazelcast for the target.
 *Usage*::
 `asadmin> restart-hazelcast --target <instance-name>`
 
+[[command-options-5]]
 === Command Options
 
 [cols=(,,,,),options="header"]
@@ -318,6 +335,7 @@ cluster.|`server`|No
 `-?`||Displays the help menu|_false_
 |====
 
+[[example-5]]
 === Example
 
 [source, shell]
@@ -327,42 +345,49 @@ instance-name:
 Hazelcast Restarted
 ----
 
+[[list-cache-keys]]
 == `list-cache-keys`
 
 _Since Payara Server 4.1.1.154_
 
 *Aim*::
-Lists all keys in a cache. If no cache is specified, keys from all caches will be returned.
+Lists all keys in a cache. If no cache is specified, keys from all caches will
+be returned.
 
 *Usage*::
 `asadmin> list-cache-keys`
 
-|===
-|Option|Type|Description|Default|Mandatory
+[[command-options-6]]
+=== Command Options
 
+[cols=(,,,,),options="header"]
+|====
+|Option|Type|Description|Default|Mandatory
 | name
 | String
-|
+| Name of the cache to query
 |
 | No
-|===
+|====
 
+[[list-caches]]
 == `list-caches`
 
 _Since Payara Server 4.1.1.154_
 
 *Aim*::
-Lists the Hazelcast Distributed Objects in the cluster
+Lists the Hazelcast distributed caches in the cluster
 
 *Usage*::
 `asadmin list-caches`
 
+[[clear-cache]]
 == `clear-cache`
 
 _Since Payara Server 4.1.1.154_
 
 *Aim*::
-Clears a Hazelcast  or Jcache IMap
+Clears a Hazelcast or JCache IMap
 
 *Usage*::
 `asadmin> clear-cache <cacheName>`

--- a/documentation/extended-documentation/hazelcast/configuration.adoc
+++ b/documentation/extended-documentation/hazelcast/configuration.adoc
@@ -12,10 +12,13 @@ specified in the Admin Console or _domain.xml_ (Note - the
 link:https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/resources/hazelcast-default.xml[Hazelcast defaults]
 are not necessarily the same as the Payara Hazelcast defaults).
 
-Since 4.1.2.172 Payara Server uses its link:https://github.com/payara/Payara/blob/master/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/PayaraHazelcastSerializer.java[own serialiser] instead of the default Hazelcast one. Setting a global serialiser will not override it.
-This was created to avoid a link:https://github.com/payara/Payara/issues/759[bug] causing ClassNotFoundExceptions.
+NOTE: Since 4.1.2.172 Payara Server uses its
+link:https://github.com/payara/Payara/blob/master/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/PayaraHazelcastSerializer.java[own serializer]
+instead of the default Hazelcast one. Setting a global serializer will not override it.
+This was created to avoid a link:https://github.com/payara/Payara/issues/759[bug]
+that causes `ClassNotFoundException` errors.
 
-
+[[setting-hazelcast-configuration-file-admin-console]]
 == Setting a Hazelcast Configuration File with the Admin Console
 
 To set the Hazelcast configuration from a Hazelcast Configuration file:
@@ -23,14 +26,15 @@ To set the Hazelcast configuration from a Hazelcast Configuration file:
 . Select the instance's configuration from the page tree and click the
 *Hazelcast* button to view the _"Hazelcast Configuration"_ page:
 +
-image::/images/hazelcast/hazelcast-select-hazelcast.png[Payara Server 4.1.2.172 Hazelcast Selection]
+image::/images/hazelcast/hazelcast-select-hazelcast.png[Hazelcast Selection in Payara Server]
 
 . On the _Hazelcast Configuration_ page, add the path to your Hazelcast
 Configuration file and click "Save". This path is relative to your domain
 configuration directory:
 +
-image::/images/hazelcast/hazelcast-admin-console-set-configuration-file.png[Payara Server 4.1.2.172 Hazelcast Set Configuration File]
+image::/images/hazelcast/hazelcast-admin-console-set-configuration-file.png[Hazelcast Set Configuration File]
 
+[[setting-hazelcast-configuration-file-asadmin]]
 == Setting a Hazelcast Configuration File using asadmin
 
 The `set-hazelcast-configuration` command can be used to set the configuration
@@ -49,7 +53,7 @@ directory.
 
 Navigate to the _Hazelcast Configuration_ page of your instances configuration.
 
-image::/images/hazelcast/hazelcast-admin-console-hazelcast-options.png[Payara 4.1.2.172 Hazelcast Options]
+image::/images/hazelcast/hazelcast-admin-console-hazelcast-options.png[Hazelcast Options]
 
 The following configuration options are available here:
 
@@ -62,12 +66,12 @@ The following configuration options are available here:
 restarted to apply any changes made
 
 |Override Configuration File |Specifies the Hazelcast configuration file
-to use. The path specified is relative to the domain config directory.
+to use. The path specified is relative to the domain _config_ directory.
 
 If you are using a custom GlassFish server configuration for a cluster
 or standalone instance (e.g. _cluster-config_), then the Hazelcast
 configuration file should be placed in the directory with the same name
-(e.g. <domain-root>/config/cluster-config). This will ensure it is
+(e.g. _<domain-root>/config/cluster-config_). This will ensure it is
 replicated to the node during startup.
 
 Using this option to point to a valid Hazelcast configuration file will cause

--- a/documentation/extended-documentation/hazelcast/enable-hazelcast.adoc
+++ b/documentation/extended-documentation/hazelcast/enable-hazelcast.adoc
@@ -1,3 +1,4 @@
+[[enabling-hazelcast]]
 = Enabling Hazelcast
 
 In the default domain configuration of Payara, Hazelcast is not enabled.
@@ -5,6 +6,7 @@ In the default domain configuration of Payara, Hazelcast is not enabled.
 It can be enabled either through the Admin Console, or by using a command line
 _asadmin_ command.
 
+[[enabling-hazelcast-admin-console]]
 == Enabling Hazelcast through the Admin Console
 
 From the Admin Console home:
@@ -22,6 +24,7 @@ restart) and save.
 +
 image::/images/hazelcast/hazelcast-admin-console-enable-hazelcast.png[Payara Server 4.1.2.172 Enabling Hazelcast]
 
+[[enabling-hazelcast-asadmin]]
 == Enabling Hazelcast using Asadmin
 
 The `set-hazelcast-configuration` asadmin command requires you to

--- a/documentation/extended-documentation/hazelcast/hazelcast.adoc
+++ b/documentation/extended-documentation/hazelcast/hazelcast.adoc
@@ -1,3 +1,4 @@
+[[hazelcast]]
 = Hazelcast
 
 This section covers how to use the Hazelcast functionality in Payara Server
@@ -5,7 +6,3 @@ This section covers how to use the Hazelcast functionality in Payara Server
 
 Hazelcast is an In-Memory Data Grid, providing Web and EJB session
 persistence, and implementing JSR107 (JCache) in Payara Server.
-
-[[configuration]]
-== Configuration
-

--- a/documentation/extended-documentation/hazelcast/using-hazelcast.adoc
+++ b/documentation/extended-documentation/hazelcast/using-hazelcast.adoc
@@ -69,18 +69,18 @@ To set up Hazelcast for persistence:
 
 . Select the instance's configuration from the page tree:
 +
-image::/images/hazelcast/hazelcast-admin-console-select-instance-config.png[Payara 4.1.2.172 Page Tree]
+image::/images/hazelcast/hazelcast-admin-console-select-instance-config.png[Page Tree]
 
 . Select _"Availability Service"_ to view the _"Availability Service"_ page:
 +
-image::/images/hazelcast/hazelcast-admin-console-select-availability-service.png[Payara 4.1.2.172 Availability Service]
+image::/images/hazelcast/hazelcast-admin-console-select-availability-service.png[Availability Service]
 
 ==== Setting Web Persistence
 
 . Open the "Web Container Availability" tab, and select "Hazelcast" from the
 Persistence Type drop-down menu:
 +
-image::/images/hazelcast/hazelcast-admin-console-availability-enable-web-persistence.png[Payara 4.1.2.172 Web Persistence]
+image::/images/hazelcast/hazelcast-admin-console-availability-enable-web-persistence.png[Web Persistence]
 
 . Save the changes.
 
@@ -89,7 +89,7 @@ image::/images/hazelcast/hazelcast-admin-console-availability-enable-web-persist
 . Open the "EJB Container Availability" tab and select "Hazelcast" from the
 Persistence Type drop-down menu:
 +
-image::/images/hazelcast/hazelcast-admin-console-availability-enable-ejb-persistence.png[Payara 4.1.2.172 EJB Persistence]
+image::/images/hazelcast/hazelcast-admin-console-availability-enable-ejb-persistence.png[EJB Persistence]
 
 . Save the changes.
 

--- a/documentation/extended-documentation/hazelcast/viewing-members.adoc
+++ b/documentation/extended-documentation/hazelcast/viewing-members.adoc
@@ -1,35 +1,40 @@
+[[viewing-hazelcast-members]]
 = Viewing Hazelcast clusters
 
 This section details how to visualize the members of a Hazelcast clusters on
 Payara Server.
 
+[[viewing-cluster-members-admin-console]]
 == Viewing Cluster Members from the Admin Console
 
 To view cluster members from the admin console:
 
+[[viewing-from-instance]]
 === Viewing from an instance
 
 . Select an instance within the cluster you wish to view from the page tree:
 +
-image::/images/hazelcast/hazelcast-admin-console-select-instance.png[Payara 4.1.2.172 Page Tree]
+image::/images/hazelcast/hazelcast-admin-console-select-instance.png[Page Tree]
 
-. Open the "Hazelcast" tab and select the "Cluster Members" sub-tab to view
+. Open the *Hazelcast* tab and select the *Cluster Members* sub-tab to view
 the cluster members page:
 +
-image::/images/hazelcast/hazelcast-admin-console-view-cluster-members.png[Payara 4.1.2.172 Cluster Members]
+image::/images/hazelcast/hazelcast-admin-console-view-cluster-members.png[Cluster Members]
 
+[[viewing-from-das]]
 === Viewing from the DAS
 
 . If Hazelcast is enabled on the DAS (`server-config`), select "_Domain_"
 from the page tree:
 +
-image::/images/hazelcast/hazelcast-admin-console-select-das.png[Payara 4.1.2.172 Page Tree]
+image::/images/hazelcast/hazelcast-admin-console-select-das.png[Page Tree]
 
 . Open the "Hazelcast" tab and select the "Cluster Members" sub-tab to view
 the cluster members page:
 +
-image::/images/hazelcast/hazelcast-admin-console-view-cluster-members-from-domain.png[Payara 4.1.2.172 Domain Cluster Members]
+image::/images/hazelcast/hazelcast-admin-console-view-cluster-members-from-domain.png[Domain Cluster Members]
 
+[[viewing-cluster-members-asadmin]]
 == Viewing Cluster Members via asadmin
 
 To view the current cluster members from the command line, run one of the following

--- a/documentation/extended-documentation/jmx-monitoring-service/jmx-notification-configuration.adoc
+++ b/documentation/extended-documentation/jmx-monitoring-service/jmx-notification-configuration.adoc
@@ -1,3 +1,4 @@
+[[jmx-notification-configuration]]
 = JMX Notification Configuration
 
 JMX Monitoring can be configured to send notifications using the
@@ -136,6 +137,7 @@ entered all values correctly, you should see a message via your chosen notifier
  with the MBeans contents:
 
 Via the logs:
+
 [source, shell]
 ----
 [2017-09-28T11:40:29.794+0100] [Payara 4.1] [INFO] [] [fish.payara.nucleus.notification.log.LogNotifierService] [tid: _ThreadID=283 _ThreadName=payara-monitoring-service(12)] [timeMillis: 1506595229794] [levelValue: 800] [[
@@ -158,6 +160,7 @@ asadmin> set-monitoring-configuration --addproperty <property>
 
 So to replicate the above properties, use the command:
 
+[source, shell]
 ----
 asadmin> set-monitoring-configuration --addproperty name activeworkcount value amx:pp=/mon/server-mon[server],type=connector-service-mon,name=jms-service/work-management description "Count all connections"
 ----

--- a/documentation/extended-documentation/notification-service/notification-service.adoc
+++ b/documentation/extended-documentation/notification-service/notification-service.adoc
@@ -1,7 +1,7 @@
 [[notification-service]]
 = Notification Service
 
-_Since Payara Server version 4.1.1.163_
+_Since Payara Server 4.1.1.163_
 
 Payara Server comes with a general Notification
 service in order to log events which come from other services, such as
@@ -33,4 +33,4 @@ log notification event that would get published by another service.
 
 The Notification service can be configured through the admin console:
 
-image:/images/notification-service/general-config.png[4.1.2.173 Notification Service General Configuration]
+image:/images/notification-service/general-config.png[Notification Service General Configuration]

--- a/documentation/user-guides/monitoring/enable-jmx-monitoring.adoc
+++ b/documentation/user-guides/monitoring/enable-jmx-monitoring.adoc
@@ -10,11 +10,11 @@ there are a few extra steps to complete first.
 Since we need to show the MBeans available, we will use VisualVM for this
 guide. This is available in the Oracle JDK as `jvisualvm`, or as a separate
 link:http://visualvm.github.io/download.html[download from visualvm.github.io].
-To view MBeans, the link:http://visualvm.github.io/plugins.html[_MBeans Browser_
-plugin] will need to be installed.
+To view MBeans, the link:http://visualvm.github.io/plugins.html[_MBeans Browser_ plugin]
+will need to be installed.
 
 With Payara Server started, VisualVM will detect the running Payara Server as an
-instance of GlassFish (provided both Payara Server and VisualVM are started as 
+instance of GlassFish (provided both Payara Server and VisualVM are started as
 the same user):
 
 image:/images/guides/monitoring/visual-vm1.png[Payara Server in VisualVM]
@@ -23,10 +23,10 @@ NOTE: This automatic detection of Payara Server uses `jstatd` to connect to the
 target JVM. MBeans are still accessible here, but this is not using JMX. A later
 guide will cover the details of connecting via a JMX port.
 
-
-=== Boot AMX
+[[boot-amx]]
+== Boot AMX
 JMX MBeans in Payara Server are exposed under `amx` to differentiate them from
-other JVM MBeans, such as those under `java.lang` which expose things like 
+other JVM MBeans, such as those under `java.lang` which expose things like
 garbage collection information.
 
 To view the MBeans from Payara Server as well as the JVM, we must execute a JMX
@@ -46,40 +46,41 @@ Expanding this directory will show a very large list of subfolders with
 useful-looking names. A closer look at these will show that the information
 in each of the MBeans is only _configuration_ information, not _metrics_. This
 is because we haven't enabled Payara Server's monitoring system, so no metrics
-are being gathered. This is our next step. 
+are being gathered. This is our next step.
 
-=== Enable Monitoring in Payara Server
-To make sure that we get all the monitoring data that Payara Server provides, 
+[[enable-monitoring-payara-server]]
+== Enable Monitoring in Payara Server
+To make sure that we get all the monitoring data that Payara Server provides,
 we will turn each module's monitoring level to `HIGH`, giving us the highest
 possible amount of data.
 
-==== Via the Admin Console
+[[via-the-admin-console]]
+=== Via the Admin Console
 Open the Admin Console and select "Monitoring Data" in the left-hand "Tree"
 pane. This is where monitoring data can be viewed in the admin console, though
 this will be raw data. Since we have not yet enabled monitoring, click the
 "Configure Monitoring" link for the relevant server instance. In the image below
 we only have the DAS ("`server`") to choose:
 
-image:/images/guides/monitoring/admin-console-monitoring1.png[Click the link for
-the relevant instance]
+image:/images/guides/monitoring/admin-console-monitoring1.png[Click the link for the relevant instance]
 
-That link will take you directly to the correct page for the `server-config` - 
+That link will take you directly to the correct page for the `server-config` -
 the place where we enable monitoring for the DAS as shown:
 
-image:/images/guides/monitoring/admin-console-monitoring2.png[Enable HIGH levels
-of monitoring]
+image:/images/guides/monitoring/admin-console-monitoring2.png[Enable HIGH levels of monitoring]
 
 Use the icon to select all available modules, change the value for the "Level"
 dropdown to `HIGH` and click "Change Level". This has not yet saved the changes,
 so we must make sure to click the "Save" button in the top left corner to make
 sure that the change is applied.
 
-==== Via the Asadmin `Set` Command
+[[via-the-asadmin-set-command]]
+=== Via the Asadmin `Set` Command
 To achieve the same goal using the `asadmin` tool, we must use the `set` command
 and the appropriate _dotted name_ for each of the modules. Below is a list of
 all the commands needed to set every module shown above to `HIGH` individually.
 
-[source]
+[source, shell]
 ----
 set configs.config.server-config.monitoring-service.module-monitoring-levels.jvm=HIGH
 set configs.config.server-config.monitoring-service.module-monitoring-levels.connector-service=HIGH
@@ -99,14 +100,14 @@ set configs.config.server-config.monitoring-service.module-monitoring-levels.orb
 set configs.config.server-config.monitoring-service.module-monitoring-levels.deployment=HIGH
 ----
 
-[#enable-jmx-view]#
+[[viewing-jmx-monitoring-data-visualvm]]
 === Viewing JMX Monitoring Data with VisualVM
-No further action needs to be taken to get the data from Payara Server into 
+No further action needs to be taken to get the data from Payara Server into
 VisualVM. If the MBeans Browser was already open before enabling monitoring,
-the new MBeans will have appeared already. They may be hard to spot, but they 
+the new MBeans will have appeared already. They may be hard to spot, but they
 are easy to identify; all MBeans which show monitoring data are suffixed with
-"-mon". A good example is `web-request-mon`, which will show metrics on requests
-for each module in the available Virtual Servers: 
+_"-mon"_. A good example is `web-request-mon`, which will show metrics on requests
+for each module in the available Virtual Servers:
 
 image:/images/guides/monitoring/visual-vm3.png[Web request metrics in VisualVM]
 

--- a/documentation/user-guides/monitoring/mbeans.adoc
+++ b/documentation/user-guides/monitoring/mbeans.adoc
@@ -1,44 +1,54 @@
 [[mbeans]]
 = MBeans in Payara Server
 
-Below is a non-exhaustive list of MBeans which are useful to monitor in Payara Server. Other MBeans not listed show static information or are JDK-specific.
+Below is a non-exhaustive list of MBeans which are useful to monitor in Payara
+Server. Other MBeans not listed show static information or are JDK-specific.
 
+[[jvm-beans]]
 == JVM MBeans
 
-==== Class Loading
+[[class-loading]]
+=== Class Loading
 
-In JMX Monitoring logging set the value to `java.lang:type=ClassLoading` to monitor this MBean
+In JMX Monitoring logging set the value to `java.lang:type=ClassLoading` to
+monitor this MBean
+
 |===
 | Attribute | Description | Comment
 
-| loadedclass-count
+| `loadedclass-count`
 | Number of classes currently loaded in the Java virtual machine
 |
 
-| totalloadedclass-count
+| `totalloadedclass-count`
 | Total number of classes that have been loaded since the Java virtual machine has started execution
 |
 
-| unloadedclass-count
+| `unloadedclass-count`
 | Total number of classes unloaded since the Java virtual machine has started execution
-| Classes are only unloaded from Payara when the application they are in is undeployed
+| Classes are only unloaded from Payara when the application they are in is undeployed.
 |===
 
-==== Compilation
+[[compilation]]
+=== Compilation
 
-In JMX Monitoring logging set the value to `java.lang:type=Compilation` to monitor this MBean
+In JMX Monitoring logging set the value to `java.lang:type=Compilation` to monitor
+this MBean
+
 |===
 | Attribute | Description | Comment
 
-| totalcompilationtime-current
-| Approximate accumlated elapsed time (in milliseconds) spent in compilation
+| `totalcompilationtime-current`
+| Approximate accumulated elapsed time (in milliseconds) spent in compilation
 |
 |===
 
-=== Garbage Collectors
+[[garbage-collectors]]
+== Garbage Collectors
 
-In JMX Monitoring logging set the value to `java.lang:type=GarbageCollector,name=collectors-name` to monitor this MBean
-The garbage collector's name will be one of the following depending on your JDK and JDK options:
+In JMX Monitoring logging set the value to `java.lang:type=GarbageCollector,name=collectors-name`
+to monitor this MBean The garbage collector's name will be one of the following
+depending on your JDK configuration options:
 
 * Copy
 * G1 Young Generation
@@ -51,737 +61,853 @@ The garbage collector's name will be one of the following depending on your JDK 
 |===
 | Attribute | Description | Comment
 
-| collectioncount-count
+| `collectioncount-count`
 | Total number of collections that have occurred
 | The number of times this garbage collector has been called since Payara was started
 
-| collectiontime-count
+| `collectiontime-count`
 | Approximate accumulated collection elapsed time in milliseconds
 | How much time has been spent on garbage collection since Payara was started
 |===
 
+[[memory]]
+=== Memory
 
-==== Memory
+In JMX Monitoring logging set the value to `java.lang:type=Memory` to monitor
+this MBean
 
-In JMX Monitoring logging set the value to `java.lang:type=Memory` to monitor this MBean
 |===
 | Attribute | Description | Comment
 
-| ObjectsPendingFinalization
+| `ObjectsPendingFinalization`
 | Approximate number of objects for which finalization is pending
 |
 
-| UsedHeapSize
+| `UsedHeapSize`
 | Amount of used memory in bytes
 |
 
-| UsedNonHeapSize
+| `UsedNonHeapSize`
 | Amount of used memory in bytes
 |
 |===
 
-==== Runtime
+[[runtime]]
+=== Runtime
 
-In JMX Monitoring logging set the value to `java.lang:type=Runtime` to monitor this MBean.
+In JMX Monitoring logging set the value to `java.lang:type=Runtime` to monitor
+this MBean.
 
 |===
 | Attribute | Description | Comment
 
-| uptime-count
+| `uptime-count`
 | Uptime of the Java virtual machine in milliseconds
 |
 |===
 
-==== Thread System
+[[thread-system]]
+=== Thread System
 
-In JMX Monitoring logging set the value to `java.lang:type=Threading` to monitor this MBean.
+In JMX Monitoring logging set the value to `java.lang:type=Threading` to monitor
+this MBean.
 
 |===
 | Attribute | Description | Comment
 
-| currentthreadcputime
+| `currentthreadcputime`
 | Returns the total CPU time for the current thread in nanoseconds
 |
 
-| currentthreadusertime
+| `currentthreadusertime`
 | Returns the CPU time that the current thread has executed in user mode in nanoseconds
 |
 
-| daemonthreadcount
+| `daemonthreadcount`
 | Returns the current number of live daemon threads
 |
 
-| deadlockedthreads
+| `deadlockedthreads`
 | Finds cycles of threads that are in deadlock waiting to acquire object monitors
 | Is either a list of deadlocked threads or the sentence "None of the threads are monitor deadlocked."
 
-| monitordeadlockedthreads
+| `monitordeadlockedthreads`
 | Finds cycles of threads that are in deadlock waiting to acquire object monitors
 | Is either a list of deadlocked threads or the sentence "None of the threads are monitor deadlocked."
 
-| peakthreadcount
+| `peakthreadcount`
 | Returns the peak live thread count since the Java virtual machine started or peak was reset
 |
 
-| threadcount
+| `threadcount`
 | Returns the current number of live threads including both daemon and non-daemon threads
 |
 
-| totalstartedthreadcount
+| `totalstartedthreadcount`
 | Returns the total number of threads created and also started since the Java virtual machine started
 |
 |===
 
-
+[[payara-mbeans]]
 == Payara MBeans
 
-These MBeans are part of Payara and provide additional information about current usage. They are all in the form of `amx:pp=amx:pp=/mon/server-mon[instance-name],type=type-of-mbean,name=MBeanName` where `instance-name` is replaced by the name of the instance i.e. `amx:pp=/mon/server-mon[server],type=web-request-mon,name=web/request`. See link:enable-jmx-monitoring.adoc#enable-jmx-view[Viewing JMX Monitoring Data] for how to view all available MBeans.
+These MBeans are part of Payara and provide additional information about current
+usage. They are all in the form of
+`amx:pp=amx:pp=/mon/server-mon[instance-name],type=type-of-mbean,name=MBeanName`
+where `instance-name` is replaced by the name of the instance i.e.
+`amx:pp=/mon/server-mon[server],type=web-request-mon,name=web/request`.
+See link:enable-jmx-monitoring.adoc#enable-jmx-view[Viewing JMX Monitoring Data]
+for how to view all available MBeans.
 
-IMPORTANT: Payara MBeans are only available when AMX is booted. This is done automatically once a JMX client connects. For all other cases, AMX must be either configured to boot at server startup or booted via a JMX operation `bootAMX` on the `amx-support:type=boot-amx` MBean.
+IMPORTANT: Payara MBeans are only available when AMX is booted. This is done
+automatically once a JMX client connects. For all other cases, AMX must be either
+configured to boot at server startup or booted via a JMX operation `bootAMX`
+on the `amx-support:type=boot-amx` MBean.
 
+[[connection-queue]]
+=== Connection Queue
 
-==== Connection Queue
+[[network-connection-queue-statistics]]
+==== Network Connection Queue Statistics
 
-Network Connection Queue Statistics
-
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=connection-queue-mon,name=network//connection-queue` to use this MBean. To monitor a specific network connection set the name value to be `network/name-of-listener/connection-queue` i.e. `name=network/http-listener-1/connection-queue`.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=connection-queue-mon,name=network//connection-queue`
+to use this MBean. To monitor a specific network connection set the name value
+to be `network/name-of-listener/connection-queue` i.e. `name=network/http-listener-1/connection-queue`.
 
 |===
 | Attribute | Description | Comment
 
-| peakqueued
+| `peakqueued`
 | Largest number of connections that were in the queue simultaneously
 |
 
-| countoverflows
+| `countoverflows`
 | Number of times the queue has been too full to accommodate a connection
 |
 
-| counttotalconnections
+| `counttotalconnections`
 | Total number of connections that have been accepted
 |
 
-| countopenconnections
+| `countopenconnections`
 | The number of open/active connections
 |
 
-| countqueued
+| `countqueued`
 | Number of connections currently in the queue
 |
 
-| countqueued1minuteaverage
+| `countqueued1minuteaverage`
 | Average number of connections queued in the last 1 minute
 |
 
-| countqueued5minutesaverage
+| `countqueued5minutesaverage`
 | Average number of connections queued in the last 5 minutes
 |
 
-| countqueued15minutesaverage
+| `countqueued15minutesaverage`
 | Average number of connections queued in the last 15 minutes
 |
 
-| counttotalqueued
+| `counttotalqueued`
 | Total number of connections that have been queued
 |
 |===
 
-==== Connector Service
+[[connector-service]]
+=== Connector Service
 
-Connector Container Work Management Statistics
+[[connector-container-work-statistics]]
+==== Connector Container Work Management Statistics
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=connector-service-mon,name=jms-service/work-management` to monitor this MBean.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=connector-service-mon,name=jms-service/work-management`
+to monitor this MBean.
 
 |===
 | Attribute | Description | Comment
 
-| activeworkcount
+| `activeworkcount`
 | Number of active work objects
 |
 
-| workrequestwaittime
+| `workrequestwaittime`
 | Wait time of a work object before it gets executed
 |
 
-| waitqueuelength
+| `waitqueuelength`
 | Number of work objects waiting in the queue for execution
 |
 
-| rejectedworkcount
+| `rejectedworkcount`
 | Number of work objects rejected by the application server
 |
 
-| submittedworkcount
+| `submittedworkcount`
 | Number of work objects submitted by a connector module for execution
 |
 
-| completedworkcount
+| `completedworkcount`
 | Number of work objects completed execution
 |
 |===
 
-==== Deployment
+[[deployment]]
+=== Deployment
 
-Deployment Module Statistics
+[[deployment-module-statistics]]
+==== Deployment Module Statistics
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=deployment-mon,name=deployment/lifecycle` to monitor this MBean.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=deployment-mon,name=deployment/lifecycle`
+to monitor this MBean.
 
 |===
 | Attribute | Description | Comment
 
-| activeapplicationsdeployedcount
+| `activeapplicationsdeployedcount`
 | Number of applications deployed
 |
 
-| totalapplicationsdeployedcount
+| `totalapplicationsdeployedcount`
 | Total number of applications ever deployed
 | This does not persist across restarts
 |===
 
-==== EJB Security
+[[ejb-security]]
+=== EJB Security
 
-Ejb Security Deployment statistics
+[[ejb-security-deployment-statistics]]
+==== EJB Security Deployment statistics
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=ejb-security-mon,name=security/ejb` to monitor this MBean.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=ejb-security-mon,name=security/ejb` to
+monitor this MBean.
 
 |===
 | Attribute | Description | Comment
 
-| policyconfigurationcount
+| `policyconfigurationcount`
 |
 | Count of EJB policy configurations
 
-| securitymanagercount
+| `securitymanagercount`
 |
 | Count of EJB security managers
 |===
 
-==== Thread Pool Executor
+[[thread-pool-executor]]
+=== Thread Pool Executor
 
-ThreadPoolExecutor Statistics
+[[thread-pool-executor-statistics]]
+==== `ThreadPoolExecutor` Statistics
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=exec-pool-mon,name=ejb/default-exec-pool` to monitor this MBean.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=exec-pool-mon,name=ejb/default-exec-pool`
+to monitor this MBean.
 
 |===
 | Attribute | Description | Comment
 
-| corenumthreads
+| `corenumthreads`
 | Core number of threads in the associated pool
 |
 
-| maxnumthreads
+| `maxnumthreads`
 | Maximum number of threads in the associated pool
 |
 
-| numthreads
+| `numthreads`
 | Current number of threads in the associated pool
 |
 
-| activenumthreads
+| `activenumthreads`
 | Number of active threads in the associated pool
 |
 
-| totaltaskscreated
+| `totaltaskscreated`
 | Number of tasks created in the associated pool
 |
 
-| keepalivetime
+| `keepalivetime`
 | Keep-Alive time for threads in the associated pool
 |
 
-| numtaskscompleted
+| `numtaskscompleted`
 | Number of tasks completed in the associated pool
 |
 
-| largestnumthreads
+| `largestnumthreads`
 | Largest number of simultaneous threads in the associated pool
 |
 |===
 
-==== JDBC Connection Pool
+[[jdbc-connection-pool]]
+=== JDBC Connection Pool
 
-JDBC Connection Statistics
+[[jdbc-connection-statistics]]
+==== JDBC Connection Statistics
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=jdbc-connection-pool-mon,name=resources/NameOfPool` to monitor this MBean, replacing NameOfPool to whatever the actual name of the pool is i.e. DerbyPool.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=jdbc-connection-pool-mon,name=resources/NameOfPool`
+to monitor this MBean, replacing `NameOfPool` to whatever the actual name of
+the pool is i.e. *DerbyPool*.
 
 |===
 | Attribute | Description | Comment
 
-| numconncreated
+| `numconncreated`
 | The number of physical connections that were created since the last reset
 |
 
-| numconndestroyed
+| `numconndestroyed`
 | Number of physical connections that were destroyed since the last reset.
 |
 
-| numconnfree
+| `numconnfree`
 | The total number of free connections in the pool as of the last sampling
 |
 
-| numpotentialconnleak
+| `numpotentialconnleak`
 | Number of potential connection leaks
 |
 
-| numconnfailedvalidation
+| `numconnfailedvalidation`
 | The total number of connections in the connection pool that failed validation from the start time until the last sample time
 |
 
-| connrequestwaittime
-| The longest and shortest wait times of connection requests. The current value indicates the wait time of the last request that was serviced by the pool.
+| `connrequestwaittime`
+| The longest and shortest wait times of connection requests. The current value
+indicates the wait time of the last request that was serviced by the pool.
 | Unit is milliseconds
 
-| numconnacquired
+| `numconnacquired`
 | Number of logical connections acquired from the pool
 |
 
-| numconnreleased
+| `numconnreleased`
 | Number of logical connections released to the pool
 |
 
-| averageconnwaittime
+| `averageconnwaittime`
 | Average wait-time-duration per successful connection request
 | Unit is milliseconds
 
-| numconnsuccessfullymatched
-| Number of connections succesfully matched
+| `numconnsuccessfullymatched`
+| Number of connections successfully matched
 |
 
-| numconnnotsuccessfullymatched
+| `numconnnotsuccessfullymatched`
 | Number of connections rejected during matching
 |
 
-| waitqueuelength
+| `waitqueuelength`
 | Number of connection requests in the queue waiting to be serviced
 |
 
-| numconntimedout
-| The total number of connections in the pool that timed out between the start time and the last sample time
+| `numconntimedout`
+| The total number of connections in the pool that timed out between the start
+time and the last sample time
 |
 |===
 
-==== Keep Alive
+[[keep-alive]]
+=== Keep Alive
 
-Keep-Alive Statistics
+[[keep-alive-statistics]]
+==== Keep-Alive Statistics
 
-This MBean is for network connections in keep-alive mode. For more details on keep-alive see https://tools.ietf.org/html/rfc7230#section-6.3[RFC 7230 6.3]. As of HTTP 1.1 all connections are keep-alive unless declared otherwise.
+This MBean is for network connections in keep-alive mode. For more details on
+`keep-alive` see https://tools.ietf.org/html/rfc7230#section-6.3[RFC 7230 6.3].
+As of *HTTP 1.1* all connections are `keep-alive` unless declared otherwise.
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=keep-alive-mon,name=network//keep-alive` to use this MBean. To monitor a specific network connection set the name value to be `network/name-of-listener/keep-alive` i.e. `name=network/http-listener-1/keep-alive`.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=keep-alive-mon,name=network//keep-alive`
+to use this MBean. To monitor a specific network connection set the name value
+to be `network/name-of-listener/keep-alive` i.e. `name=network/http-listener-1/keep-alive`.
 
 |===
 | Attribute | Description | Comment
 
-| counttimeouts
+| `counttimeouts`
 | Number of keep-alive connections that timed out
 |
 
-| counthits
+| `counthits`
 | Number of requests received by connections in keep-alive mode
 |
 
-| countconnections
+| `countconnections`
 | Number of connections in keep-alive mode
 |
 
-| countflushes
+| `countflushes`
 | Number of keep-alive connections that were closed
 |
 
-| countrefusals
+| `countrefusals`
 | Number of keep-alive connections that were rejected
 |
 |===
 
-==== Managed Executor Service
+[[managed-executor-service]]
+=== Managed Executor Service
 
-ManagedExecutorService Statistics
+[[managed-executor-service-statistics]]
+==== `ManagedExecutorService` Statistics
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=managed-executor-service-mon,name=executorService/concurrent/NameOfManagedExecutorService` to use this MBean, replacing `NameOfManagedExecutorService` to whatever the actual name of the service is i.e. `__defaultManagedExecutorService`.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=managed-executor-service-mon,name=executorService/concurrent/NameOfManagedExecutorService`
+to use this MBean, replacing `NameOfManagedExecutorService` to whatever the actual
+name of the service is i.e. `__defaultManagedExecutorService`.
 
 |===
 | Attribute | Description | Comment
 
-| PoolSize
+| `PoolSize`
 | The current number of threads in the pool
 |
 
-| ActiveCount
+| `ActiveCount`
 | The approximate number of active threads
 |
 
-| CompletedTaskCount
+| `CompletedTaskCount`
 | Number of tasks completed
 |
 
-| LargestPoolSize
+| `LargestPoolSize`
 | The largest number of threads that have ever simultaneously been in the pool
 |
 
-| TaskCount
-| TaskCount
+| `TaskCount`
+| The number of tasks executed by the executor service
 |
 |===
 
-==== Message Driven Beans
+[[message-driven-beans]]
+=== Message Driven Beans
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=message-driven-bean-mon,name=applicationName/ClassUsingBean` to use this MBean, replacing `applicationName` with the name of your application using JMS and `ClassUsingBean` with the class that has the `@MessageDriven` annotation on it.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=message-driven-bean-mon,name=applicationName/ClassUsingBean`
+to use this MBean, replacing `applicationName` with the name of your application
+using JMS and `ClassUsingBean` with the class that has the `@MessageDriven`
+annotation on it.
 
 |===
 | Attribute | Description | Comment
 
-| createcount
+| `createcount`
 | Number of times EJB create method is called
 |
 
-| removecount
+| `removecount`
 | Number of times EJB remove method is called
 |
 
-| messagecount
+| `messagecount`
 | Number of messages received for the message-driven bean
 |
 |===
 
+[[request]]
+=== Request
 
-==== Request
+[[web-container-http-statistics]]
+==== Web Container HTTP Service Statistics
 
-Web Container HTTP Service Statistics
-
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=request-mon,name=http-service/VirtualServer/request` to use this MBean, replacing `VirtualServer` name of the virtual server it is running on. This MBean differs from Connection Queue statistics by being selected by virtual server rather than by listener, as well as providing some additional information about responses.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=request-mon,name=http-service/VirtualServer/request`
+to use this MBean, replacing `VirtualServer` name of the virtual server it is
+running on. This MBean differs from Connection Queue statistics by being selected
+by virtual server rather than by listener, as well as providing some additional
+information about responses.
 
 |===
 | Attribute | Description | Comment
 
-| method
+| `method`
 | The method of the last request serviced
-| This will be one of GET, HEAD, POST, PUT, DELETE, TRACE, OPTIONS, CONNECT or PATCH
+| This will be one of `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `TRACE`, `OPTIONS`,
+`CONNECT` or `PATCH`
 
-| countopenconnections
+| `countopenconnections`
 | The number of open connections
-| Unlike most other attributes with count in the name, this one is the currrent number rather than total over the server lifetime
+| Unlike most other attributes with count in the name, this one is the current
+number rather than total over the server lifetime
 
-| countrequests
+| `countrequests`
 | The number of requests received
-| The number of requests recived since the server was started
+| The number of requests received since the server was started
 
-| uri
+| `uri`
 | The URI of the last request serviced
 |
 
-| maxtime
-| Longest response time for a request; not a cumulative value, but the largest response time from among the response times
+| `maxtime`
+| Longest response time for a request; not a cumulative value, but the largest
+response time from among the response times
 |
 
-| count200
-| Number of responses with a status code equal to 200
+| `count200`
+| Number of responses with a status code equal to *200*
 | This is the total since the server started
 
-| count2xx
-| Number of responses with a status code in the 2xx range
+| `count2xx`
+| Number of responses with a status code in the *2xx* range
 | This is the total since the server started
 
-| count302
-| Number of responses with a status code equal to 302
+| `count302`
+| Number of responses with a status code equal to *302*
 | This is the total since the server started
 
-| count304
-| Number of responses with a status code equal to 304
+| `count304`
+| Number of responses with a status code equal to *304*
 | This is the total since the server started
 
-| count3xx
-| Number of responses with a status code in the 3xx range
+| `count3xx`
+| Number of responses with a status code in the *3xx* range
 | This is the total since the server started
 
-| count400
-| Number of responses with a status code equal to 400
+| `count400`
+| Number of responses with a status code equal to *400*
 | This is the total since the server started
 
-| count401
-| Number of responses with a status code equal to 401
+| `count401`
+| Number of responses with a status code equal to *401*
 | This is the total since the server started
 
-| count403
-| Number of responses with a status code equal to 403
+| `count403`
+| Number of responses with a status code equal to *403*
 | This is the total since the server started
 
-| count404
-| Number of responses with a status code equal to 404
+| `count404`
+| Number of responses with a status code equal to *404*
 | This is the total since the server started
 
-| count4xx
-| Number of responses with a status code in the 4xx range
+| `count4xx`
+| Number of responses with a status code in the *4xx* range
 | This is the total since the server started
 
-| count503
-| Number of responses with a status code in the 5xx range
+| `count503`
+| Number of responses with a status code in the *5xx* range
 | This is the total since the server started
 
-| countother
-| Number of responses with a status code outside the 2xx, 3xx, 4xx, and 5xx range
+| `countother`
+| Number of responses with a status code outside the *2xx*, *3xx*, *4xx*, and *5xx* range
 | This is the total since the server started
 
-| countbytestransmitted
+| `countbytestransmitted`
 | The number of bytes transmitted
 |
 
-| countbytesreceived
+| `countbytesreceived`
 | The number of bytes received
 |
 
-| errorcount
-| Cumulative value of the error count, with error count representing the number of cases where the response code was greater than or equal to 400
+| `errorcount`
+| Cumulative value of the error count, with error count representing the number
+of cases where the response code was greater than or equal to *400*
 |
 
-| processingtime
+| `processingtime`
 | Average request processing time
 | Unit is milliseconds
 |===
 
-==== Security Realm
+[[security-realm]]
+=== Security Realm
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=security-realm-mon,name=security/realm` to use this MBean.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=security-realm-mon,name=security/realm`
+to use this MBean.
 
 |===
 | Attribute | Description | Comment
 
-| RealmCount
+| `RealmCount`
 | Security Realm Count
 |
 |===
 
-==== Server
+[[server]]
+=== Server
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=server-runtime-mon` to use this MBean.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=server-runtime-mon` to use this MBean.
 
 |===
 | Attribute | Description | Comment
 
-| state
-| state of the server such as Running, Stopped, Failed
+| `state`
+| state of the server such as *Running*, *Stopped*, *Failed*
 |
 
-| uptime
+| `uptime`
 | uptime of the Java virtual machine in milliseconds
 |
 |===
 
-==== Servlet
+[[servlet]]
+=== Servlet
 
-Web Container Servlet Statistics
+[[web-container-servlet-statistics]]
+==== Web Container Servlet Statistics
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=servlet-mon,name=ApplicationName/InstanceName/ServletName` to use this MBean, where `ApplicationName` is the name of your application and `InstanceName` is the instance it is running. This MBean provides information on all servlets within an application.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=servlet-mon,name=ApplicationName/InstanceName/ServletName`
+to use this MBean, where `ApplicationName` is the name of your application and
+`InstanceName` is the instance it is running. This MBean provides information on
+all servlets within an application.
 
 |===
 | Attribute | Description | Comment
 
-| totalservletsloadedcount
+| `totalservletsloadedcount`
 | Total number of Servlets ever loaded
 |
 
-| activeservletsloadedcount
+| `activeservletsloadedcount`
 | Number of Servlets loaded
 |
 
-| servletprocessingtimes
+| `servletprocessingtimes`
 | Cumulative Servlet processing times
 | Unit is milliseconds
 |===
 
+[[web-container-servlet-instance-statistics]]
+==== Web Container Servlet Instance Statistics
 
-==== Servlet Instances
-
-Web Container Servlet Instance Statistics
-
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=servlet-instance-mon,name=ApplicationName/VirtualServerName/ServletName` to use this MBean, where `ApplicationName` is the name of your application, `VirtualServerName` is the virtual server it is running on and `ServletName` is the name of the servlet to access. If the servlet is annotation with ``@WebServlet(name = "ServletName")`` then the servlet name will be the name in the annotation, otherwise it is the fully qualified class name.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=servlet-instance-mon,name=ApplicationName/VirtualServerName/ServletName`
+to use this MBean, where `ApplicationName` is the name of your application,
+`VirtualServerName` is the virtual server it is running on and `ServletName`
+is the name of the servlet to access. If the servlet is annotation with
+`@WebServlet(name = "ServletName")` then the servlet name will be the name in the
+annotation, otherwise it is the fully qualified class name.
 
 |===
 | Attribute | Description | Comment
 
-| errorcount
+| `errorcount`
 | Number of error responses (that is, responses with a status code greater than or equal to 400)
 |
 
-| requestcount
+| `requestcount`
 | Number of requests processed
 |
 
-| processingtime
+| `processingtime`
 | Average response time
 | Unit is milliseconds
 
-| maxtime
+| `maxtime`
 | Maximum response time
 | Unit is milliseconds
 
-| servicetime
+| `servicetime`
 | Aggregate response time
 |
 |===
 
-==== Singleton Bean
+[[singleton-bean]]
+=== Singleton Bean
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=singleton-bean-mon,name=ApplicationsName/ClassName` where `ApplicationName` is the name of your application and `ClassName` of the name of the Singleton EJB class.
-
-|===
-| Attribute | Description | Comment
-
-| createcount
-| Number of times EJB create method is called
-|
-
-| removecount
-| Number of times EJB remove method is called
-|
-|===
-
-==== Stateful Bean
-
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=stateful-bean-mon,name=ApplicationsName/ClassName` where `ApplicationName` is the name of your application and `ClassName` of the name of the Stateful EJB class.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=singleton-bean-mon,name=ApplicationsName/ClassName`
+where `ApplicationName` is the name of your application and `ClassName` of the
+name of the Singleton EJB class.
 
 |===
 | Attribute | Description | Comment
 
-| createcount
+| `createcount`
 | Number of times EJB create method is called
 |
 
-| removecount
+| `removecount`
+| Number of times EJB remove method is called
+|
+|===
+
+[[stateful-bean]]
+=== Stateful Bean
+
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=stateful-bean-mon,name=ApplicationsName/ClassName`
+where `ApplicationName` is the name of your application and `ClassName` of the
+name of the Stateful EJB class.
+
+|===
+| Attribute | Description | Comment
+
+| `createcount`
+| Number of times EJB create method is called
+|
+
+| `removecount`
 | Number of times EJB remove method is called
 |
 
-| methodreadycount
-| Number of stateful session beans in MethodReady state
+| `methodreadycount`
+| Number of stateful session beans in `MethodReady` state
 |
 
-| passivecount
+| `passivecount`
 | Number of stateful session beans in Passive state
 |
 |===
 
-==== Stateless Bean
+[[stateless-bean]]
+=== Stateless Bean
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=stateless-bean-mon,name=ApplicationsName/ClassName` where `ApplicationName` is the name of your application and `ClassName` of the name of the Stateless EJB class.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=stateless-bean-mon,name=ApplicationsName/ClassName`
+where `ApplicationName` is the name of your application and `ClassName` of the
+name of the Stateless EJB class.
 
 |===
 | Attribute | Description | Comment
 
-| createcount
+| `createcount`
 | Number of times EJB create method is called
 |
 
-| removecount
+| `removecount`
 | Number of times EJB remove method is called
 |
 
-| methodreadycount
-| Number of stateful session beans in MethodReady state
+| `methodreadycount`
+| Number of stateful session beans in `MethodReady` state
 |
 |===
 
+[[thread-pool]]
+=== Thread Pool
 
-==== Thread Pool
+[[thread-pool-statistics]]
+==== Thread Pool Statistics
 
-Thread Pool Statistics
-
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=thread-pool-mon,name=network/NetworkListenerName/thread-pool` where `NetworkListenerName` is the name of the network listener to monitor. Alternatively set value to `amx:pp=/mon/server-mon[server],type=thread-pool-mon,name=network//global-thread-pool-stats` for totals across all thread pools.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=thread-pool-mon,name=network/NetworkListenerName/thread-pool`
+where `NetworkListenerName` is the name of the network listener to monitor.
+Alternatively set the value to `amx:pp=/mon/server-mon[server],type=thread-pool-mon,name=network//global-thread-pool-stats`
+for totals across all thread pools.
 
 |===
 | Attribute | Description | Comment
 
-| corethreads
+| `corethreads`
 | Core number of threads in the thread pool
 |
 
-| totalexecutedtasks
+| `totalexecutedtasks`
 | Provides the total number of tasks, which were executed by the thread pool
 |
 
-| maxthreads
+| `maxthreads`
 | Maximum number of threads allowed in the thread pool
 |
 
-| currentthreadcount
+| `currentthreadcount`
 | Provides the number of request processing threads currently in the listener thread pool
 |
 
-| currentthreadsbusy
+| `currentthreadsbusy`
 | Provides the number of request processing threads currently in use in the listener thread pool serving requests
 |
 |===
 
-==== Transaction Service
+[[transaction-service]]
+=== Transaction Service
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=transaction-service-mon,name=transaction-service` to use this MBean.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=transaction-service-mon,name=transaction-service`
+to use this MBean.
 
 |===
 | Attribute | Description | Comment
 
-| activecount
+| `activecount`
 | Provides the number of transactions that are currently active.
 |
 
-| committedcount
+| `committedcount`
 | Provides the number of transactions that have been committed.
 |
 
-| rolledbackcount
+| `rolledbackcount`
 | Provides the number of transactions that have been rolled back.
 |
 
-| state
+| `state`
 | Indicates if the transaction service has been frozen.
-| Is False if service is working fine
+| Returns `false` if service is working fine
 |===
 
-==== Virtual Server
+[[virtual-server]]
+=== Virtual Server
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=virtualserverinfo-mon,name=http-service/VirtualServerName` where `VirtualServerName` is the name of the virtual server.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=virtualserverinfo-mon,name=http-service/VirtualServerName`
+where `VirtualServerName` is the name of the virtual server.
 
 |===
 | Attribute | Description | Comment
 
-| id
+| `id`
 | The id of the virtual server
 |
 
-| hosts
+| `hosts`
 | The host (alias) names of the virtual server"
 |
 
-| mode
+| `mode`
 | The mode of the virtual server
 | Is either active or unknown
 
-| state
+| `state`
 | The state of the virtual server
 |
 |===
 
-
+[[web-request]]
 ==== Web Request
 
-In JMX Logging set value to `amx:pp=/mon/server-mon[server],type=web-request-mon,name=ApplicationName/VirtualServer` where `ApplicationName` is the name of your application and `VirtualServer` is the name of the virtual server it is running on. There is also the special value of web/request for all requests to every virtual servier and application.
+In JMX Logging set value to
+`amx:pp=/mon/server-mon[server],type=web-request-mon,name=ApplicationName/VirtualServer`
+where `ApplicationName` is the name of your application and `VirtualServer` is
+the name of the virtual server it is running on. There is also the special value of
+`web/request` for all requests to every virtual server and application.
 
 |===
 | Attribute | Description | Comment
 
-| errorcount
-| Cumulative value of the error count, with error count representing the number of cases where the response code was greater than or equal to 400
+| `errorcount`
+| Cumulative value of the error count, with error count representing the number of
+cases where the response code was greater than or equal to *400*
 |
 
-| requestcount
+| `requestcount`
 | Cumulative number of requests processed so far
 |
 
-| processingtime
+| `processingtime`
 | Average request processing time
 |
 
-| maxtime
-| Longest response time for a request; not a cumulative value, but the largest response time from among the response times
+| `maxtime`
+| Longest response time for a request; not a cumulative value, but the largest
+response time from among the response times
 |
 |===
 
 == OpenMQ MBeans
 
-Payara Server includes OpenMQ as a JMS broker, which includes its own MBeans. Documentation on them can be found at http://docs.oracle.com/cd/E19906-01/820-5207/gcakw/index.html
+Payara Server includes OpenMQ as a JMS broker, which includes its own MBeans.
+Documentation on them can be found in the official
+link:https://javaee.github.io/glassfish/doc/4.0/mq-dev-guide-jmx.pdf[GlassFish reference guide for coding JMX clients].
+Check section 3: _Message Queue MBean Reference_


### PR DESCRIPTION
Fixes for multiple pending changes needed to finish the #273 PR
Changes made:

* Added missing reference anchors for Hazelcast, JMS Monitoring and Monitoring Guide articles.
* Removed version disclaimer from multiple image alt texts.
* Fixed broken tables in the Hazelcast section
* Improved format for MBean reference documentation. Changed link to outdated GlassFish documentation.