### PR TITLE
MP version and URL variables

### DIFF
--- a/SUMMARY.adoc
+++ b/SUMMARY.adoc
@@ -164,6 +164,8 @@
 * link:documentation/microprofile/README.adoc[MicroProfile]
 ** link:documentation/microprofile/config.adoc[Config API]
 ** link:documentation/microprofile/metrics.adoc[Metrics API]
+** link:documentation/microprofile/healthcheck.adoc[Health Check API]
+** link:documentation/microprofile/faulttolerance.adoc[Fault Tolerance API]
 * link:documentation/ecosystem/ecosystem.adoc[Ecosystem]
 ** link:documentation/ecosystem/maven-plugin.adoc[Payara Micro Maven Plugin]
 ** link:documentation/ecosystem/netbeans-plugin.adoc[Payara NetBeans Plugin]

--- a/book.json
+++ b/book.json
@@ -22,7 +22,15 @@
     "variables": {
         "currentVersion": "4.1.2.181",
         "glassfishVersion": "4",
+        "mpConfigVersion": "1.1",
+        "mpConfigSpecUrl": "https://github.com/eclipse/microprofile-config/releases/tag/1.1",
         "mpMetricsVersion": "1.0",
-        "mpMetricsSpecUrl": "https://github.com/eclipse/microprofile-metrics/releases/tag/1.0"
+        "mpMetricsSpecUrl": "https://github.com/eclipse/microprofile-metrics/releases/tag/1.0",
+        "mpHealthVersion": "1.0",
+        "mpHealthSpecUrl": "https://github.com/eclipse/microprofile-health/releases/tag/1.0",
+        "mpFaultToleranceVersion": "1.0",
+        "mpFaultToleranceSpecUrl": "https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/1.0",
+        "mpJwtVersion": "1.0",
+        "mpJwtSpecUrl": "https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.0"
     }
 }

--- a/documentation/microprofile/README.adoc
+++ b/documentation/microprofile/README.adoc
@@ -27,11 +27,11 @@ therefore, supports all specifications of MicroProfile.
 * JAX-RS 2.0
 * CDI 1.2
 * JSON-P 1.0
-* https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/1.0[Fault Tolerance 1.0]
-* https://github.com/eclipse/microprofile-health/releases/tag/1.0[Health 1.0]
-* https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.0[Json Web Token 1.0]
-* https://github.com/eclipse/microprofile-metrics/releases/tag/1.0[Metrics 1.0]
-* https://github.com/eclipse/microprofile-config/releases/tag/1.1[Config 1.1]
+* {{ book.mpConfigSpecUrl }}[Config {{ book.mpConfigVersion }}]
+* {{ book.mpMetricsSpecUrl }}[Metrics {{ book.mpMetricsVersion }}]
+* {{ book.mpHealthSpecUrl }}[Health Check{{ book.mpHealthVersion }}]
+* {{ book.mpFaultToleranceSpecUrl }}[Fault Tolerance {{ book.mpFaultToleranceVersion }}]
+* {{ book.mpJwtSpecUrl }}[JWT Access Control {{ book.mpJwtVersion }}]
 
 
 | [source, xml]

--- a/documentation/microprofile/config.adoc
+++ b/documentation/microprofile/config.adoc
@@ -1,5 +1,9 @@
 = Eclipse MicroProfile Config API
 
+_Since *4.1.2.173*&nbsp;_
+
+Provided version of the API: {{ book.mpConfigSpecUrl }}[MicroProfile Config {{ book.mpConfigVersion }}]
+
 == Background
 The Config API was created to allow for the modification of application
 configuration from outside the application without needing the application to be

--- a/documentation/microprofile/faulttolerance.adoc
+++ b/documentation/microprofile/faulttolerance.adoc
@@ -1,5 +1,9 @@
 = Eclipse MicroProfile Fault Tolerance API
 
+_Since *4.1.2.181*; *5.181*&nbsp;_
+
+Provided version of the API: {{ book.mpFaultToleranceSpecUrl }}[MicroProfile Fault Tolerance {{ book.mpFaultToleranceVersion }}]
+
 == Background
 The Fault Tolerance API was created to help separate execution logic from execution. 
 The execution can be configured with a number of fault tolerance policies.

--- a/documentation/microprofile/healthcheck.adoc
+++ b/documentation/microprofile/healthcheck.adoc
@@ -1,4 +1,8 @@
-= Eclipse MicroProfile Healthchecks API
+= Eclipse MicroProfile Health Check API
+
+_Since *4.1.2.181*; *5.181*&nbsp;_
+
+Provided version of the API: {{ book.mpHealthSpecUrl }}[MicroProfile Health Check {{ book.mpHealthVersion }}]
 
 == Background
 The Health Check API was created to allow easier probing of the state of 


### PR DESCRIPTION
Added version info for each API page.
Using variables to specify version and URL for the current version of each MP API implemented by Payara. Makes it easy to update all in one place later.

A preview: https://docs.payara.fish/v/181-MP-fixes/documentation/microprofile/