### PR TITLE
Add support for IBM JDK and AIX

### DIFF
--- a/general-info/supported-platforms.adoc
+++ b/general-info/supported-platforms.adoc
@@ -14,6 +14,9 @@ Payara Server currently supports the following Java Virtual Machines:
 * Oracle JDK8 (u162+)
 * Azul Zulu JDK8 (u162+)
 * OpenJDK JDK8 (u162+)
+* IBM Java SDK 8 ()
+
+NOTE: A separate Payara Blue distribution is no longer required for IBM Java SDK.
 
 == Supported Operating Systems
 * Windows
@@ -28,3 +31,4 @@ Payara Server currently supports the following Java Virtual Machines:
 ** SUSE 11.4 & 12.2+
 * Other
 ** MacOS(OSX) 10.10.5 (Yosemite)+
+** IBM AIX 

--- a/general-info/supported-platforms.adoc
+++ b/general-info/supported-platforms.adoc
@@ -14,7 +14,7 @@ Payara Server currently supports the following Java Virtual Machines:
 * Oracle JDK8 (u162+)
 * Azul Zulu JDK8 (u162+)
 * OpenJDK JDK8 (u162+)
-* IBM Java SDK 8 ()
+* IBM Java SDK 8
 
 NOTE: A separate Payara Blue distribution is no longer required for IBM Java SDK.
 


### PR DESCRIPTION
It's still missing oldest supported versions for IBM SDK and AIX, please comment if you know which versions we support them since.