### PR TITLE
PAYARA-3462 added section on new health check asadmin commands

### DIFF
--- a/documentation/payara-server/health-check-service/asadmin-commands.adoc
+++ b/documentation/payara-server/health-check-service/asadmin-commands.adoc
@@ -9,15 +9,18 @@ to correctly configure the HealthCheck Service.
 
 *Usage*::
 ----
-set-healthcheck-configuration --enabled=true|false --dynamic=true|false  
---trace-enabled=true|false --trace-store-size=20 
---trace-store-timeout=<integer.value>s|m|h|d]
+set-healthcheck-configuration 
+ --enabled=true|false 
+ --dynamic=true|false  
+ --historic-trace-enabled=true|false 
+ --historic-trace-store-size=20 
+ --historic-trace-store-timeout=<integer.value>s|m|h|d
 ----
 
 *Aim*::
 Enables and disables the HealthCheck service. This includes configuration for tracing historic health check events for later inspection. 
 
-[[command-options]]
+[[command-options-8]]
 ==== Command Options
 
 [cols="3,1,5,1,1",options="header"]
@@ -46,26 +49,20 @@ Enables and disables the HealthCheck service. This includes configuration for tr
 |N/A
 |yes
 
-|`--notifierenabled`
-|Boolean
-|Whether or not to enable the default notifier
-|false
-|no
-
-|`--trace-enabled`
+|`--historic-trace-enabled`
 |Boolean
 |Enables historic checks if present
 |false |no
 
-|`--trace-store-size`
+|`--historic-trace-store-size`
 |Integer
 |Sets the maximum number of health checks to store
 |20
 |no
 
-|`--trace-store-timeout`
+|`--historic-trace-store-timeout`
 |String
-|Sets the time period after which a historic health check event entry is removed from visable history. The time expression should consist of a single number followed by a time unit, `s` for seconds, `m` for minutes, `h` for hours or `d` for days. If no time unit is given the number specifies seconds. If the parameter is zero or unspecified there is no timeout for entries.
+|Sets the time period after which a historic health check event entry is removed from visable history. The time expression should consist of a number followed by a time unit; `s` for seconds, `m` for minutes, `h` for hours or `d` for days. If no time unit is given the number specifies seconds. If the parameter is zero or unspecified there is no timeout for entries.
 |-
 |no
 
@@ -85,8 +82,8 @@ notifier and sets the historical trace store to retain 20 health checks.
 asadmin> set-healthcheck-configuration
     --enabled=true
     --dynamic=false
-    --trace-enabled=true
-    --trace-store-size=20
+    --historic-trace-enabled=true
+    --historic-trace-store-size=20
 ----
 
 [[healthcheck-configure]]
@@ -180,7 +177,7 @@ asadmin > healthcheck-configure
 *Aim*::
 Lists the names of all available metric checker services.
 
-[[command-options-1]]
+[[command-options-9]]
 ==== Command Options
 
 There are no options available.
@@ -240,24 +237,28 @@ Command healthcheck-list-services executed successfully.
 == `set-healthcheck-service-configuration`
 
 *Usage*::
+
 ----
 set-healthcheck-service-configuration 
-    --service=<service.name>
-    --enabled=true|false
-    --dynamic=true|false 
-    --time=<integer.value>
-    --time-unit=MICROSECONDS|MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS
-    --threshold-critical=80 --threshold-warning=50 --threshold-good=0
-    --hogging-threads-threshold=<integer.value>
-    --hogging-threads-retry-count=<integer.value>
-    --stuck-threads-threshold=<integer.value>
-    --stuck-threads-threshold-unit=DAYS|HOURS|MICROSECONDS|MILLISECONDS|MINUTES|NANOSECONDS|SECONDS
+ --service=<service.name>
+ --enabled=true|false
+ --dynamic=true|false 
+ --time=<integer.value>
+ --time-unit=DAYS|HOURS|MINUTES|SECONDS|MILLISECONDS
+ --threshold-critical=80 
+ --threshold-warning=50 
+ --threshold-good=0
+ --hogging-threads-threshold=<integer.value>
+ --hogging-threads-retry-count=<integer.value>
+ --stuck-threads-threshold=<integer.value>
+ --stuck-threads-threshold-unit=DAYS|HOURS|MINUTES|SECONDS|MILLISECONDS
 ----
 
 *Aim*::
 Enables or disables the monitoring of an specific metric. The command
 also configures the frequency of monitoring for that metric. Furthermore it configures metric specific properties.
 
+[[command-options-10]]
 ==== Command Options
 
 [cols="3,1,5,3a,1",options="header",]
@@ -812,8 +813,97 @@ asadmin> healthcheck-stuckthreads-configure
     --thresholdUnit=MINUTES
 ----
 
+[[set-healthcheck-service-notifier-configuration]]
+== `set-healthcheck-service-notifier-configuration`
+
+*Usage*::
+
+----
+asadmin> set-healthcheck-service-notifier-configuration
+ --notifier=<string.value>
+ --enabled=true|false 
+ --dynamic=true|false 
+ --noisy=true|false
+----
+
+*Aim*::
+This command can be used to enable or disable a specific notifier or to change its noisy setting.
+
+[[command-options-14]]
+==== Command Options
+
+[cols=",,,,",options="header",]
+|===
+|Option
+|Type
+|Description
+|Default
+|Mandatory
+
+| `--notifier`
+| String
+a| The notifier to configure. One of (case insensitive):
+
+* `LOG`
+* `HIPCHAT`
+* `SLACK`
+* `JMS`
+* `EMAIL`
+* `XMPP`
+* `SNMP`
+* `EVENTBUS`
+* `NEWRELIC`
+* `DATADOG`
+* `CDIEVENTBUS`
+
+| -
+| yes
+
+|`--enable`
+|Boolean
+|Enables or disables the notifier
+|false
+|Yes
+
+|`--noisy`
+|Boolean
+|Sets the notfier to noisy or not noisy. If not set no change is applied to current setting.
+|-
+|No
+
+|`--dynamic`
+|Boolean
+|Whether to apply the changes directly to the server/instance without a restart
+|false
+|No
+
+| `--target`
+| String
+| The instance or cluster that will be configured
+| server
+| no
+
+|===
+
+[[example-14]]
+==== Examples
+
+To enable the log notifier for the HealthCheck Service without having to
+restart the server, use the following command:
+
+[source, shell]
+----
+asadmin> set-healthcheck-service-notifier-configuration
+ --notifier=log
+ --enabled=true
+ --dynamic=true
+----
+
+
 [[healthcheck-notifier-configure]]
 == `healthcheck-[NOTIFIER_NAME]-notifier-configure`
+
+NOTE: This is deprecated in 5.191 and will be removed in the future as it is replaced with the <<set-healthcheck-service-notifier-configuration>> command.
 
 *Usage*::
 `asadmin> healthcheck-[NOTIFIER_NAME]-notifier-configure --enabled=true --dynamic=true`

--- a/documentation/payara-server/health-check-service/asadmin-commands.adoc
+++ b/documentation/payara-server/health-check-service/asadmin-commands.adoc
@@ -68,12 +68,12 @@ Enables and disables the HealthCheck service. This includes configuration for tr
 
 |===
 
-NOTE: Enabling or disabling the health check service in general implicitly also enables or disables the log notifier which is the default notifier. This behaviour is similar to the replaced <<healthcheck-configure>> command.
+NOTE: Enabling or disabling the health check service implicitly also enables or disables the log notifier which is the default notifier. This behaviour is similar to the replaced <<healthcheck-configure>> command.
 
 [[example-8]]
 ==== Example
 
-The following example will enabled the Healthcheck service such that it will
+The following example will enable the Healthcheck service such that it will
 only activate from the next time the server is restarted. It enables the log
 notifier and sets the historical trace store to retain 20 health checks.
 
@@ -154,7 +154,7 @@ command to enable or disable other available notifiers.
 [[example]]
 ==== Example
 
-The following example will enabled the Healthcheck service such that it will
+The following example will enable the Healthcheck service such that it will
 only activate from the next time the server is restarted. It enables the log
 notifier and sets the historical trace store to retain 20 health checks.
 
@@ -867,7 +867,7 @@ a| The notifier to configure. One of (case insensitive):
 
 |`--noisy`
 |Boolean
-|Sets the notfier to noisy or not noisy. If not set no change is applied to current setting.
+|Sets the notifier to noisy (a.k.a verbose) or not noisy. A noisy notifier includes `FINE` log level in its output. If not set no change is applied to current setting.
 |-
 |No
 

--- a/documentation/payara-server/health-check-service/asadmin-commands.adoc
+++ b/documentation/payara-server/health-check-service/asadmin-commands.adoc
@@ -171,8 +171,42 @@ asadmin > healthcheck-configure
     --historicaltracestoresize=20
 ----
 
+[[list-healthcheck-services]]
+== `list-healthcheck-services` 
+
+*Usage*::
+`asadmin> list-healthcheck-services`
+
+*Aim*::
+Lists the names of all available metric checker services.
+
+[[command-options-1]]
+==== Command Options
+
+There are no options available.
+
+[[list-healthcheck-services-example-1]]
+==== Example
+
+Running the command will show output similar to the example below:
+
+----
+Available Health Check Services:
+        healthcheck-cpool
+        healthcheck-cpu
+        healthcheck-gc
+        healthcheck-heap
+        healthcheck-threads
+        healthcheck-machinemem
+
+Command healthcheck-list-services executed successfully.
+----
+
+
 [[healthcheck-list-services]]
-== `healthcheck-list-services`
+== `healthcheck-list-services` 
+
+NOTE: This is deprecated in 5.191 and will be removed in the future as it is replaced with the <<list-healthcheck-services>> command.
 
 *Usage*::
 `asadmin> healthcheck-list-services`

--- a/documentation/payara-server/health-check-service/asadmin-commands.adoc
+++ b/documentation/payara-server/health-check-service/asadmin-commands.adoc
@@ -51,7 +51,7 @@ Enables and disables the HealthCheck service. This includes configuration for tr
 
 |`--historic-trace-enabled`
 |Boolean
-|Enables historic checks if present
+|Enables storing traces in a rolling store for later inspection
 |false |no
 
 |`--historic-trace-store-size`

--- a/documentation/payara-server/health-check-service/asadmin-commands.adoc
+++ b/documentation/payara-server/health-check-service/asadmin-commands.adoc
@@ -867,7 +867,7 @@ a| The notifier to configure. One of (case insensitive):
 
 |`--noisy`
 |Boolean
-|Sets the notifier to noisy (a.k.a verbose) or not noisy. A noisy notifier includes `FINE` log level in its output. If not set no change is applied to current setting.
+|Sets the notifier to noisy (a.k.a verbose) or not noisy. A noisy notifier includes more detailed logging information in the notifiers output.
 |-
 |No
 

--- a/documentation/payara-server/health-check-service/asadmin-commands.adoc
+++ b/documentation/payara-server/health-check-service/asadmin-commands.adoc
@@ -73,7 +73,7 @@ Enables and disables the HealthCheck service. This includes configuration for tr
 
 NOTE: Enabling or disabling the health check service in general implicitly also enables or disables the log notifier which is the default notifier. This behaviour is similar to the replaced <<healthcheck-configure>> command.
 
-[[example]]
+[[example-8]]
 ==== Example
 
 The following example will enabled the Healthcheck service such that it will
@@ -185,7 +185,7 @@ Lists the names of all available metric checker services.
 
 There are no options available.
 
-[[list-healthcheck-services-example-1]]
+[[example-9]]
 ==== Example
 
 Running the command will show output similar to the example below:
@@ -236,8 +236,211 @@ Available Health Check Services:
 Command healthcheck-list-services executed successfully.
 ----
 
+[[set-healthcheck-service-configuration]]
+== `set-healthcheck-service-configuration`
+
+*Usage*::
+----
+set-healthcheck-service-configuration 
+    --service=<service.name>
+    --enabled=true|false
+    --dynamic=true|false 
+    --time=<integer.value>
+    --time-unit=MICROSECONDS|MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS
+    --threshold-critical=80 --threshold-warning=50 --threshold-good=0
+    --hogging-threads-threshold=<integer.value>
+    --hogging-threads-retry-count=<integer.value>
+    --stuck-threads-threshold=<integer.value>
+    --stuck-threads-threshold-unit=DAYS|HOURS|MICROSECONDS|MILLISECONDS|MINUTES|NANOSECONDS|SECONDS
+----
+
+*Aim*::
+Enables or disables the monitoring of an specific metric. The command
+also configures the frequency of monitoring for that metric. Furthermore it configures metric specific properties.
+
+==== Command Options
+
+[cols="3,1,5,3a,1",options="header",]
+|===
+| Option
+| Type
+| Description
+| Default
+| Mandatory
+
+| `--target`
+| String
+| The instance or cluster that will enable or disable its metric configuration
+| server
+| no
+
+| `--dynamic`
+| Boolean
+| Whether to apply the changes directly to the server/instance without a restart
+| false
+| no
+
+| `--enabled`
+| Boolean
+| Whether to enable or disable the metric monitoring
+| N/A
+| yes
+
+| `--service`
+| String
+a| The service metric name. One of:
+
+  * `connection-pool` or `cp`
+  * `cpu-usage` or  `cu`
+  * `garbage-collector` or `gc`
+  * `heap-memory-usage` or `hmu`
+  * `hogging-threads` or `ht`
+  * `machine-memory-usage` or `mmu`
+  * `stuck-thread` or `st`
+  * `mp-health` or `mh`
+
+| -
+| yes
+
+| `--time`
+| Integer
+| The amount of time units that the service will use to periodically monitor the metric
+| 5
+| no
+
+| `--time-unit`
+| TimeUnit
+| The time unit to set the frequency of the metric monitoring. Must correspond to a valid
+https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeUnit.html[`java.util.concurrent.TimeUnit`]
+value
+| `MINUTES`
+| no
+
+| `--threshold-critical`
+| Integer
+| The threshold value that this metric must surpass to generate a **`CRITICAL`** event. A value between _WARNING VALUE_ and _100_ must be used. Available for services `cp`, `cu`, `gc`, `hmu` and `mmu`.
+| 90
+| no
+
+| `--threshold-warning`
+| Integer
+| The threshold value that this metric must surpass to generate a **`WARNING`** event. A value between _GOOD VALUE_ and _CRITICAL VALUE_ must be used. Available for services `cp`, `cu`, `gc`, `hmu` and `mmu`.
+| 50
+| no
+
+| `--threshold-good`
+| Integer
+| The threshold value that this metric must surpass to generate a **`GOOD`** event. A value between _0_ and _WARNING VALUE_ must be used. Available for services `cp`, `cu`, `gc`, `hmu` and `mmu`.
+| 0
+| no
+
+| `--hogging-threads-threshold`
+| Integer
+| The threshold value that this metric will be compared to mark threads as hogging the CPU. Only available for `ht` service.
+| 95
+| no
+
+| `--hogging-threads-retry-count`
+| Integer
+| The number of retries that the checker service will execute in order to identify a hogging thread. Only available for `ht` service.
+| 3
+| no
+
+|`--stuck-threads-threshold`
+|Integer
+|The threshold above which a thread is considered stuck. Must be 1 or greater. Only available for `st` service.
+|-
+|no
+
+|`--stuck-threads-threshold-unit`
+|link:https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeUnit.html[`TimeUnit`]
+|The unit for the threshold for when a thread should be considered stuck. Only available for `st` service.
+|-
+|no
+
+|===
+
+NOTE: If this command gets executed before running the <<set-healthcheck-configuration>>
+command, it will succeed and the configuration will be saved, but the HealthCheck
+service will not be enabled.
+
+[[example-10]]
+==== Examples
+A very basic example command to simply enable the GC checker and activate it without
+needing a restart would be as follows:
+
+[source, shell]
+----
+asadmin> set-healthcheck-service-configuration 
+ --enabled=true
+ --service=gc
+ --dynamic=true
+----
+
+[[example-11]]
+Monitoring the health of JDBC connection pools is a common need. In that
+scenario, it is very unlikely that on-the-fly configuration changes
+would be made, so a very high `CRITICAL` threshold can be set. Likewise,
+a nonzero `GOOD` threshold is needed because an empty or unused
+connection pool may not be healthy either.
+
+The following command would apply these settings to the connection pool
+checker:
+
+[source, shell]
+----
+asadmin> set-healthcheck-service-configuration
+ --service=cp
+ --dynamic=true
+ --threshold-critical=95
+ --threshold-warning=70
+ --threshold-good=30
+----
+
+[[example-12]]
+Monitoring which threads hog the CPU is extremely important since this can lead
+to performance degradation, deadlocks and extreme bottlenecks issues that web
+applications can incur. In some cases the defaults are all that is needed, but imagine
+that in a critical system you want to set the threshold percentage to **90%**,
+and you want to make sure that the health check service guarantees the state of such
+threads with a retry count of *5*. Additionally, you want to set the frequency of
+this check for every _20 seconds_.
+
+The following command would apply these settings to the connection pool checker:
+
+[source, shell]
+----
+asadmin> set-healthcheck-service-configuration
+ --service=cp
+ --dynamic=true
+ --hogging-threads-threshold=90
+ --hogging-threads-retry-count=5
+ --time=20
+ --time-unit=SECONDS
+----
+
+[[example-13]]
+The following example configures the stuck threads checker to check every 30
+seconds for any threads which have been stuck for more than 5 minutes and
+applies the configuration change without needing a restart:
+
+[source, Shell]
+----
+asadmin> set-healthcheck-service-configuration
+ --service=stuck-thread
+ --enabled=true
+ --dynamic=true
+ --time=30
+ --time-unit=SECONDS
+ --stuck-threads-threshold=5
+ --stuck-threads-threshold-unit=MINUTES
+----
+
+
 [[healthcheck-configure-service]]
 == `healthcheck-configure-service`
+
+NOTE: This is deprecated in 5.191 and will be removed in the future as it is replaced with the <<set-healthcheck-service-configuration>> command.
 
 *Usage*::
 `asadmin> healthcheck-configure-service --serviceName=<service.name>
@@ -335,6 +538,8 @@ asadmin> healthcheck-configure-service --enabled=true
 [[healthcheck-configure-service-threshold]]
 == `healthcheck-configure-service-threshold`
 
+NOTE: This is deprecated in 5.191 and will be removed in the future as it is replaced with the <<set-healthcheck-service-configuration>> command.
+
 *Usage*::
 `asadmin> healthcheck-configure-service-threshold --serviceName=<service.name>
 --dynamic=true|false --thresholdCritical=90 --thresholdWarning=50 --thresholdGood=0`
@@ -427,6 +632,8 @@ asadmin> healthcheck-configure-service-threshold
 
 [[healthcheck-hoggingthreads-configure]]
 == `healthcheck-hoggingthreads-configure`
+
+NOTE: This is deprecated in 5.191 and will be removed in the future as it is replaced with the <<set-healthcheck-service-configuration>> command.
 
 *Usage*::
 `asadmin> healthcheck-hoggingthreads-configure --dynamic=true|false --threshold-percentage=50 --retry-count=3`
@@ -522,6 +729,8 @@ asadmin> healthcheck-hoggingthreads-configure
 
 [[healthcheck-stuckthreads-configure]]
 == `healthcheck-stuckthreads-configure`
+
+NOTE: This is deprecated in 5.191 and will be removed in the future as it is replaced with the <<set-healthcheck-service-configuration>> command.
 
 *Usage*::
 `asadmin> healthcheck-stuckthreads-configure --enabled true|false --dynamic true|false

--- a/documentation/payara-server/health-check-service/asadmin-commands.adoc
+++ b/documentation/payara-server/health-check-service/asadmin-commands.adoc
@@ -4,8 +4,95 @@
 The following is a detailed list of the administration commands that can be used
 to correctly configure the HealthCheck Service.
 
+[[set-healthcheck-configuration]]
+== `set-healthcheck-configuration`
+
+*Usage*::
+----
+set-healthcheck-configuration --enabled=true|false --dynamic=true|false  
+--trace-enabled=true|false --trace-store-size=20 
+--trace-store-timeout=<integer.value>s|m|h|d]
+----
+
+*Aim*::
+Enables and disables the HealthCheck service. This includes configuration for tracing historic health check events for later inspection. 
+
+[[command-options]]
+==== Command Options
+
+[cols="3,1,5,1,1",options="header"]
+|===
+|Option
+|Type
+|Description
+|Default
+|Mandatory
+
+|`--target`
+|String
+|The instance or cluster that will enable or disable its service
+|server
+|no
+
+|`--dynamic`
+|Boolean
+|Whether to apply the changes directly to the server without a restart
+|false
+|no
+
+|`--enabled`
+|Boolean
+|Whether to enable or disable the service
+|N/A
+|yes
+
+|`--notifierenabled`
+|Boolean
+|Whether or not to enable the default notifier
+|false
+|no
+
+|`--trace-enabled`
+|Boolean
+|Enables historic checks if present
+|false |no
+
+|`--trace-store-size`
+|Integer
+|Sets the maximum number of health checks to store
+|20
+|no
+
+|`--trace-store-timeout`
+|String
+|Sets the time period after which a historic health check event entry is removed from visable history. The time expression should consist of a single number followed by a time unit, `s` for seconds, `m` for minutes, `h` for hours or `d` for days. If no time unit is given the number specifies seconds. If the parameter is zero or unspecified there is no timeout for entries.
+|-
+|no
+
+|===
+
+NOTE: Enabling or disabling the health check service in general implicitly also enables or disables the log notifier which is the default notifier. This behaviour is similar to the replaced <<healthcheck-configure>> command.
+
+[[example]]
+==== Example
+
+The following example will enabled the Healthcheck service such that it will
+only activate from the next time the server is restarted. It enables the log
+notifier and sets the historical trace store to retain 20 health checks.
+
+[source, shell]
+----
+asadmin> set-healthcheck-configuration
+    --enabled=true
+    --dynamic=false
+    --trace-enabled=true
+    --trace-store-size=20
+----
+
 [[healthcheck-configure]]
 == `healthcheck-configure`
+
+NOTE: This is deprecated in 5.191 and will be removed in the future as it is replaced with the <<set-healthcheck-configuration>> command.
 
 *Usage*::
 `asadmin> healthcheck-configure --enabled=true|false --dynamic=true|false --historicaltraceenabled --historicaltracestoresize=20`

--- a/documentation/payara-server/health-check-service/asadmin-commands.html
+++ b/documentation/payara-server/health-check-service/asadmin-commands.html
@@ -539,7 +539,7 @@ Enabling or disabling the health check service in general implicitly also enable
 </div>
 </div>
 <div class="sect3">
-<h4 id="example"><a class="anchor" href="#example"></a>Example</h4>
+<h4 id="example-8"><a class="anchor" href="#example-8"></a>Example</h4>
 <div class="paragraph">
 <p>The following example will enabled the Healthcheck service such that it will
 only activate from the next time the server is restarted. It enables the log
@@ -707,7 +707,7 @@ notifier and sets the historical trace store to retain 20 health checks.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="list-healthcheck-services-example-1"><a class="anchor" href="#list-healthcheck-services-example-1"></a>Example</h4>
+<h4 id="example-9"><a class="anchor" href="#example-9"></a>Example</h4>
 <div class="paragraph">
 <p>Running the command will show output similar to the example below:</p>
 </div>
@@ -782,8 +782,316 @@ Command healthcheck-list-services executed successfully.</pre>
 </div>
 </div>
 <div class="sect1">
+<h2 id="set-healthcheck-service-configuration"><a class="anchor" href="#set-healthcheck-service-configuration"></a><code>set-healthcheck-service-configuration</code></h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+</dl>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>set-healthcheck-service-configuration
+    --service=&lt;service.name&gt;
+    --enabled=true|false
+    --dynamic=true|false
+    --time=&lt;integer.value&gt;
+    --time-unit=MICROSECONDS|MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS
+    --threshold-critical=80 --threshold-warning=50 --threshold-good=0
+    --hogging-threads-threshold=&lt;integer.value&gt;
+    --hogging-threads-retry-count=&lt;integer.value&gt;
+    --stuck-threads-threshold=&lt;integer.value&gt;
+    --stuck-threads-threshold-unit=DAYS|HOURS|MICROSECONDS|MILLISECONDS|MINUTES|NANOSECONDS|SECONDS</pre>
+</div>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>Enables or disables the monitoring of an specific metric. The command
+also configures the frequency of monitoring for that metric. Furthermore it configures metric specific properties.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="truecommand-options"><a class="anchor" href="#truecommand-options"></a>Command Options</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 23.0769%;">
+<col style="width: 7.6923%;">
+<col style="width: 38.4615%;">
+<col style="width: 23.0769%;">
+<col style="width: 7.6924%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Option</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Mandatory</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--target</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The instance or cluster that will enable or disable its metric configuration</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>server</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--dynamic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to apply the changes directly to the server/instance without a restart</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>false</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--enabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to enable or disable the metric monitoring</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>N/A</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--service</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>The service metric name. One of:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>connection-pool</code> or <code>cp</code></p>
+</li>
+<li>
+<p><code>cpu-usage</code> or  <code>cu</code></p>
+</li>
+<li>
+<p><code>garbage-collector</code> or <code>gc</code></p>
+</li>
+<li>
+<p><code>heap-memory-usage</code> or <code>hmu</code></p>
+</li>
+<li>
+<p><code>hogging-threads</code> or <code>ht</code></p>
+</li>
+<li>
+<p><code>machine-memory-usage</code> or <code>mmu</code></p>
+</li>
+<li>
+<p><code>stuck-thread</code> or <code>st</code></p>
+</li>
+<li>
+<p><code>mp-health</code> or <code>mh</code></p>
+</li>
+</ul>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--time</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The amount of time units that the service will use to periodically monitor the metric</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--time-unit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TimeUnit</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The time unit to set the frequency of the metric monitoring. Must correspond to a valid
+<a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeUnit.html"><code>java.util.concurrent.TimeUnit</code></a>
+value</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p><code>MINUTES</code></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--threshold-critical</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The threshold value that this metric must surpass to generate a <strong><code>CRITICAL</code></strong> event. A value between <em>WARNING VALUE</em> and <em>100</em> must be used. Available for services <code>cp</code>, <code>cu</code>, <code>gc</code>, <code>hmu</code> and <code>mmu</code>.</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>90</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--threshold-warning</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The threshold value that this metric must surpass to generate a <strong><code>WARNING</code></strong> event. A value between <em>GOOD VALUE</em> and <em>CRITICAL VALUE</em> must be used. Available for services <code>cp</code>, <code>cu</code>, <code>gc</code>, <code>hmu</code> and <code>mmu</code>.</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>50</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--threshold-good</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The threshold value that this metric must surpass to generate a <strong><code>GOOD</code></strong> event. A value between <em>0</em> and <em>WARNING VALUE</em> must be used. Available for services <code>cp</code>, <code>cu</code>, <code>gc</code>, <code>hmu</code> and <code>mmu</code>.</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>0</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--hogging-threads-threshold</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The threshold value that this metric will be compared to mark threads as hogging the CPU. Only available for <code>ht</code> service.</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>95</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--hogging-threads-retry-count</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The number of retries that the checker service will execute in order to identify a hogging thread. Only available for <code>ht</code> service.</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>3</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--stuck-threads-threshold</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The threshold above which a thread is considered stuck. Must be 1 or greater. Only available for <code>st</code> service.</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--stuck-threads-threshold-unit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeUnit.html"><code>TimeUnit</code></a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The unit for the threshold for when a thread should be considered stuck. Only available for <code>st</code> service.</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+</tbody>
+</table>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+If this command gets executed before running the <a href="#set-healthcheck-configuration"><code>set-healthcheck-configuration</code></a>
+command, it will succeed and the configuration will be saved, but the HealthCheck
+service will not be enabled.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="example-10"><a class="anchor" href="#example-10"></a>Examples</h4>
+<div class="paragraph">
+<p>A very basic example command to simply enable the GC checker and activate it without
+needing a restart would be as follows:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; set-healthcheck-service-configuration
+ --enabled=true
+ --service=gc
+ --dynamic=true</code></pre>
+</div>
+</div>
+<div id="example-11" class="paragraph">
+<p>Monitoring the health of JDBC connection pools is a common need. In that
+scenario, it is very unlikely that on-the-fly configuration changes
+would be made, so a very high <code>CRITICAL</code> threshold can be set. Likewise,
+a nonzero <code>GOOD</code> threshold is needed because an empty or unused
+connection pool may not be healthy either.</p>
+</div>
+<div class="paragraph">
+<p>The following command would apply these settings to the connection pool
+checker:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; set-healthcheck-service-configuration
+ --service=cp
+ --dynamic=true
+ --threshold-critical=95
+ --threshold-warning=70
+ --threshold-good=30</code></pre>
+</div>
+</div>
+<div id="example-12" class="paragraph">
+<p>Monitoring which threads hog the CPU is extremely important since this can lead
+to performance degradation, deadlocks and extreme bottlenecks issues that web
+applications can incur. In some cases the defaults are all that is needed, but imagine
+that in a critical system you want to set the threshold percentage to <strong>90%</strong>,
+and you want to make sure that the health check service guarantees the state of such
+threads with a retry count of <strong>5</strong>. Additionally, you want to set the frequency of
+this check for every <em>20 seconds</em>.</p>
+</div>
+<div class="paragraph">
+<p>The following command would apply these settings to the connection pool checker:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; set-healthcheck-service-configuration
+ --service=cp
+ --dynamic=true
+ --hogging-threads-threshold=90
+ --hogging-threads-retry-count=5
+ --time=20
+ --time-unit=SECONDS</code></pre>
+</div>
+</div>
+<div id="example-13" class="paragraph">
+<p>The following example configures the stuck threads checker to check every 30
+seconds for any threads which have been stuck for more than 5 minutes and
+applies the configuration change without needing a restart:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-Shell" data-lang="Shell">asadmin&gt; set-healthcheck-service-configuration
+ --service=stuck-thread
+ --enabled=true
+ --dynamic=true
+ --time=30
+ --time-unit=SECONDS
+ --stuck-threads-threshold=5
+ --stuck-threads-threshold-unit=MINUTES</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
 <h2 id="healthcheck-configure-service"><a class="anchor" href="#healthcheck-configure-service"></a><code>healthcheck-configure-service</code></h2>
 <div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+This is deprecated in 5.191 and will be removed in the future as it is replaced with the <a href="#set-healthcheck-service-configuration"><code>set-healthcheck-service-configuration</code></a> command.
+</td>
+</tr>
+</table>
+</div>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>Usage</strong></dt>
@@ -945,6 +1253,18 @@ needing a restart would be as follows:</p>
 <div class="sect1">
 <h2 id="healthcheck-configure-service-threshold"><a class="anchor" href="#healthcheck-configure-service-threshold"></a><code>healthcheck-configure-service-threshold</code></h2>
 <div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+This is deprecated in 5.191 and will be removed in the future as it is replaced with the <a href="#set-healthcheck-service-configuration"><code>set-healthcheck-service-configuration</code></a> command.
+</td>
+</tr>
+</table>
+</div>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>Usage</strong></dt>
@@ -1098,6 +1418,18 @@ checker:</p>
 <div class="sect1">
 <h2 id="healthcheck-hoggingthreads-configure"><a class="anchor" href="#healthcheck-hoggingthreads-configure"></a><code>healthcheck-hoggingthreads-configure</code></h2>
 <div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+This is deprecated in 5.191 and will be removed in the future as it is replaced with the <a href="#set-healthcheck-service-configuration"><code>set-healthcheck-service-configuration</code></a> command.
+</td>
+</tr>
+</table>
+</div>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>Usage</strong></dt>
@@ -1234,6 +1566,18 @@ checker:</p>
 <div class="sect1">
 <h2 id="healthcheck-stuckthreads-configure"><a class="anchor" href="#healthcheck-stuckthreads-configure"></a><code>healthcheck-stuckthreads-configure</code></h2>
 <div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+This is deprecated in 5.191 and will be removed in the future as it is replaced with the <a href="#set-healthcheck-service-configuration"><code>set-healthcheck-service-configuration</code></a> command.
+</td>
+</tr>
+</table>
+</div>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>Usage</strong></dt>
@@ -1517,7 +1861,7 @@ Command get-healthcheck-configuration executed successfully.</pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-02-04 15:49:15 CET
+Last updated 2019-02-05 11:06:50 CET
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">

--- a/documentation/payara-server/health-check-service/asadmin-commands.html
+++ b/documentation/payara-server/health-check-service/asadmin-commands.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.5">
+<meta name="generator" content="Asciidoctor 1.5.5.dev">
 <title>HealthCheck Service Asadmin Command Reference</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
@@ -17,6 +17,7 @@ audio:not([controls]){display:none;height:0}
 [hidden],template{display:none}
 script{display:none!important}
 html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+body{margin:0}
 a{background:transparent}
 a:focus{outline:thin dotted}
 a:active,a:hover{outline:0}
@@ -51,7 +52,7 @@ textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
 *,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
 html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -63,6 +64,7 @@ img{-ms-interpolation-mode:bicubic}
 .text-center{text-align:center!important}
 .text-justify{text-align:justify!important}
 .hide{display:none}
+body{-webkit-font-smoothing:antialiased}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
@@ -117,16 +119,13 @@ table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
 table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
 table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+body{tab-size:4}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
 .clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
 .clearfix:after,.float-group:after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-*:not(pre)>code.nobreak{word-wrap:normal}
-*:not(pre)>code.nowrap{white-space:nowrap}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
 pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
-em em{font-style:normal}
-strong strong{font-weight:400}
 .keyseq{color:rgba(51,51,51,.8)}
 kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
 .keyseq kbd:first-child{margin-left:0}
@@ -417,6 +416,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .hide-for-print{display:none!important}
 .show-for-print{display:inherit!important}}
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">
 </head>
 <body id="healthcheck-service" class="article">
 <div id="header">
@@ -432,8 +432,146 @@ to correctly configure the HealthCheck Service.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="healthcheck-configure"><code>healthcheck-configure</code></h2>
+<h2 id="set-healthcheck-configuration"><a class="anchor" href="#set-healthcheck-configuration"></a><code>set-healthcheck-configuration</code></h2>
 <div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+</dl>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>set-healthcheck-configuration --enabled=true|false --dynamic=true|false
+--trace-enabled=true|false --trace-store-size=20
+--trace-store-timeout=&lt;integer.value&gt;s|m|h|d]</pre>
+</div>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>Enables and disables the HealthCheck service. This includes configuration for tracing historic health check events for later inspection.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options"><a class="anchor" href="#command-options"></a>Command Options</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 27.2727%;">
+<col style="width: 9.0909%;">
+<col style="width: 45.4545%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.091%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Option</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Mandatory</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--target</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The instance or cluster that will enable or disable its service</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">server</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--dynamic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to apply the changes directly to the server without a restart</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--enabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to enable or disable the service</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--notifierenabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether or not to enable the default notifier</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--trace-enabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enables historic checks if present</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--trace-store-size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Sets the maximum number of health checks to store</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--trace-store-timeout</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Sets the time period after which a historic health check event entry is removed from visable history. The time expression should consist of a single number followed by a time unit, <code>s</code> for seconds, <code>m</code> for minutes, <code>h</code> for hours or <code>d</code> for days. If no time unit is given the number specifies seconds. If the parameter is zero or unspecified there is no timeout for entries.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+</tbody>
+</table>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+Enabling or disabling the health check service in general implicitly also enables or disables the log notifier which is the default notifier. This behaviour is similar to the replaced <a href="#healthcheck-configure"><code>healthcheck-configure</code></a> command.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="example"><a class="anchor" href="#example"></a>Example</h4>
+<div class="paragraph">
+<p>The following example will enabled the Healthcheck service such that it will
+only activate from the next time the server is restarted. It enables the log
+notifier and sets the historical trace store to retain 20 health checks.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; set-healthcheck-configuration
+    --enabled=true
+    --dynamic=false
+    --trace-enabled=true
+    --trace-store-size=20</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="healthcheck-configure"><a class="anchor" href="#healthcheck-configure"></a><code>healthcheck-configure</code></h2>
+<div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+This is deprecated in 5.191 and will be removed in the future as it is replaced with the <a href="#set-healthcheck-configuration"><code>set-healthcheck-configuration</code></a> command.
+</td>
+</tr>
+</table>
+</div>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>Usage</strong></dt>
@@ -447,7 +585,7 @@ to correctly configure the HealthCheck Service.</p>
 </dl>
 </div>
 <div class="sect3">
-<h4 id="command-options">Command Options</h4>
+<h4 id="command-options"><a class="anchor" href="#command-options"></a>Command Options</h4>
 <table class="tableblock frame-all grid-all spread">
 <colgroup>
 <col style="width: 27.2727%;">
@@ -514,7 +652,7 @@ to correctly configure the HealthCheck Service.</p>
 <table>
 <tr>
 <td class="icon">
-<div class="title">Important</div>
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
 Starting from release <em>4.1.1.171</em>, the <code>--notifierenabled</code> argument is
@@ -528,7 +666,7 @@ command to enable or disable other available notifiers.
 </div>
 </div>
 <div class="sect3">
-<h4 id="example">Example</h4>
+<h4 id="example"><a class="anchor" href="#example"></a>Example</h4>
 <div class="paragraph">
 <p>The following example will enabled the Healthcheck service such that it will
 only activate from the next time the server is restarted. It enables the log
@@ -536,7 +674,7 @@ notifier and sets the historical trace store to retain 20 health checks.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin &gt; healthcheck-configure
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin &gt; healthcheck-configure
     --enabled=true
     --dynamic=false
     --notifierenabled=true
@@ -548,13 +686,13 @@ notifier and sets the historical trace store to retain 20 health checks.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="healthcheck-list-services"><code>healthcheck-list-services</code></h2>
+<h2 id="list-healthcheck-services"><a class="anchor" href="#list-healthcheck-services"></a><code>list-healthcheck-services</code></h2>
 <div class="sectionbody">
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>Usage</strong></dt>
 <dd>
-<p><code>asadmin&gt; healthcheck-list-services</code></p>
+<p><code>asadmin&gt; list-healthcheck-services</code></p>
 </dd>
 <dt class="hdlist1"><strong>Aim</strong></dt>
 <dd>
@@ -563,13 +701,13 @@ notifier and sets the historical trace store to retain 20 health checks.</p>
 </dl>
 </div>
 <div class="sect3">
-<h4 id="command-options-1">Command Options</h4>
+<h4 id="command-options-1"><a class="anchor" href="#command-options-1"></a>Command Options</h4>
 <div class="paragraph">
 <p>There are no options available.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="example-1">Example</h4>
+<h4 id="list-healthcheck-services-example-1"><a class="anchor" href="#list-healthcheck-services-example-1"></a>Example</h4>
 <div class="paragraph">
 <p>Running the command will show output similar to the example below:</p>
 </div>
@@ -590,7 +728,61 @@ Command healthcheck-list-services executed successfully.</pre>
 </div>
 </div>
 <div class="sect1">
-<h2 id="healthcheck-configure-service"><code>healthcheck-configure-service</code></h2>
+<h2 id="healthcheck-list-services"><a class="anchor" href="#healthcheck-list-services"></a><code>healthcheck-list-services</code></h2>
+<div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+This is deprecated in 5.191 and will be removed in the future as it is replaced with the <a href="#list-healthcheck-services"><code>list-healthcheck-services</code></a> command.
+</td>
+</tr>
+</table>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+<dd>
+<p><code>asadmin&gt; healthcheck-list-services</code></p>
+</dd>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>Lists the names of all available metric checker services.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options-1"><a class="anchor" href="#command-options-1"></a>Command Options</h4>
+<div class="paragraph">
+<p>There are no options available.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="example-1"><a class="anchor" href="#example-1"></a>Example</h4>
+<div class="paragraph">
+<p>Running the command will show output similar to the example below:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>Available Health Check Services:
+        healthcheck-cpool
+        healthcheck-cpu
+        healthcheck-gc
+        healthcheck-heap
+        healthcheck-threads
+        healthcheck-machinemem
+
+Command healthcheck-list-services executed successfully.</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="healthcheck-configure-service"><a class="anchor" href="#healthcheck-configure-service"></a><code>healthcheck-configure-service</code></h2>
 <div class="sectionbody">
 <div class="dlist">
 <dl>
@@ -608,7 +800,7 @@ also configures the frequency of monitoring for that metric.</p>
 </dl>
 </div>
 <div class="sect3">
-<h4 id="command-options-2">Command Options</h4>
+<h4 id="command-options-2"><a class="anchor" href="#command-options-2"></a>Command Options</h4>
 <table class="tableblock frame-all grid-all spread">
 <colgroup>
 <col style="width: 23.0769%;">
@@ -722,7 +914,7 @@ value</p></td>
 <table>
 <tr>
 <td class="icon">
-<div class="title">Note</div>
+<i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
 If this command gets executed before running the <code>healthcheck-configure</code>
@@ -734,14 +926,14 @@ service will not be enabled.
 </div>
 </div>
 <div class="sect3">
-<h4 id="example-2">Example</h4>
+<h4 id="example-2"><a class="anchor" href="#example-2"></a>Example</h4>
 <div class="paragraph">
 <p>A very basic example command to simply enable the GC checker and activate it without
 needing a restart would be as follows:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-configure-service --enabled=true
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-configure-service --enabled=true
       --serviceName=healthcheck-gc
       --name=MYAPP-GC
       --dynamic=true</code></pre>
@@ -751,7 +943,7 @@ needing a restart would be as follows:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="healthcheck-configure-service-threshold"><code>healthcheck-configure-service-threshold</code></h2>
+<h2 id="healthcheck-configure-service-threshold"><a class="anchor" href="#healthcheck-configure-service-threshold"></a><code>healthcheck-configure-service-threshold</code></h2>
 <div class="sectionbody">
 <div class="dlist">
 <dl>
@@ -788,7 +980,7 @@ the changes directly.</p>
 </dl>
 </div>
 <div class="sect3">
-<h4 id="command-options-3">Command Options</h4>
+<h4 id="command-options-3"><a class="anchor" href="#command-options-3"></a>Command Options</h4>
 <table class="tableblock frame-all grid-all spread">
 <colgroup>
 <col style="width: 23.0769%;">
@@ -867,7 +1059,7 @@ the changes directly.</p>
 <table>
 <tr>
 <td class="icon">
-<div class="title">Note</div>
+<i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
 In order to execute this command for an specific metric, the
@@ -878,7 +1070,7 @@ In order to execute this command for an specific metric, the
 </div>
 </div>
 <div class="sect3">
-<h4 id="example-3">Example</h4>
+<h4 id="example-3"><a class="anchor" href="#example-3"></a>Example</h4>
 <div class="paragraph">
 <p>Monitoring the health of JDBC connection pools is a common need. In that
 scenario, it is very unlikely that on-the-fly configuration changes
@@ -892,7 +1084,7 @@ checker:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-configure-service-threshold
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-configure-service-threshold
  --serviceName=healthcheck-cpool
  --dynamic=true
  --thresholdCritical=95
@@ -904,7 +1096,7 @@ checker:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="healthcheck-hoggingthreads-configure"><code>healthcheck-hoggingthreads-configure</code></h2>
+<h2 id="healthcheck-hoggingthreads-configure"><a class="anchor" href="#healthcheck-hoggingthreads-configure"></a><code>healthcheck-hoggingthreads-configure</code></h2>
 <div class="sectionbody">
 <div class="dlist">
 <dl>
@@ -926,7 +1118,7 @@ frequency as you would do with the <code>healthcheck-configure-service</code> co
 </dl>
 </div>
 <div class="sect3">
-<h4 id="command-options-4">Command Options</h4>
+<h4 id="command-options-4"><a class="anchor" href="#command-options-4"></a>Command Options</h4>
 <table class="tableblock frame-all grid-all spread">
 <colgroup>
 <col style="width: 23.0769%;">
@@ -1012,7 +1204,7 @@ frequency as you would do with the <code>healthcheck-configure-service</code> co
 </table>
 </div>
 <div class="sect3">
-<h4 id="example-4">Example</h4>
+<h4 id="example-4"><a class="anchor" href="#example-4"></a>Example</h4>
 <div class="paragraph">
 <p>Monitoring which threads hog the CPU is extremely important since this can lead
 to performance degradation, deadlocks and extreme bottlenecks issues that web
@@ -1028,7 +1220,7 @@ checker:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-hoggingthreads-configure
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-hoggingthreads-configure
  --dynamic=true
  --threshold-percentage=90
  --retry-count=5
@@ -1040,7 +1232,7 @@ checker:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="healthcheck-stuckthreads-configure"><code>healthcheck-stuckthreads-configure</code></h2>
+<h2 id="healthcheck-stuckthreads-configure"><a class="anchor" href="#healthcheck-stuckthreads-configure"></a><code>healthcheck-stuckthreads-configure</code></h2>
 <div class="sectionbody">
 <div class="dlist">
 <dl>
@@ -1057,7 +1249,7 @@ checker:</p>
 </dl>
 </div>
 <div class="sect3">
-<h4 id="command-options-5">Command Options</h4>
+<h4 id="command-options-5"><a class="anchor" href="#command-options-5"></a>Command Options</h4>
 <table class="tableblock frame-all grid-all spread">
 <colgroup>
 <col style="width: 23.0769%;">
@@ -1143,7 +1335,7 @@ checker:</p>
 </table>
 </div>
 <div class="sect3">
-<h4 id="example-5">Example</h4>
+<h4 id="example-5"><a class="anchor" href="#example-5"></a>Example</h4>
 <div class="paragraph">
 <p>The following example configures the stuckthreads checker to check every 30
 seconds for any threads which have been stuck for more than 5 minutes and
@@ -1151,7 +1343,7 @@ applies the configuration change without needing a restart:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-Shell" data-lang="Shell">asadmin&gt; healthcheck-stuckthreads-configure
+<pre class="highlightjs highlight"><code class="language-Shell" data-lang="Shell">asadmin&gt; healthcheck-stuckthreads-configure
     --enabled=true
     --dynamic=true
     --time=30
@@ -1164,7 +1356,7 @@ applies the configuration change without needing a restart:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="healthcheck-notifier-configure"><code>healthcheck-[NOTIFIER_NAME]-notifier-configure</code></h2>
+<h2 id="healthcheck-notifier-configure"><a class="anchor" href="#healthcheck-notifier-configure"></a><code>healthcheck-[NOTIFIER_NAME]-notifier-configure</code></h2>
 <div class="sectionbody">
 <div class="dlist">
 <dl>
@@ -1180,7 +1372,7 @@ the <em>[NOTIFIER_NAME]</em> placeholder.</p>
 </dl>
 </div>
 <div class="sect3">
-<h4 id="command-options-6">Command Options</h4>
+<h4 id="command-options-6"><a class="anchor" href="#command-options-6"></a>Command Options</h4>
 <table class="tableblock frame-all grid-all spread">
 <colgroup>
 <col style="width: 20%;">
@@ -1219,7 +1411,7 @@ the <em>[NOTIFIER_NAME]</em> placeholder.</p>
 <table>
 <tr>
 <td class="icon">
-<div class="title">Tip</div>
+<i class="fa icon-tip" title="Tip"></i>
 </td>
 <td class="content">
 You can find the list of available notifiers using the
@@ -1230,7 +1422,7 @@ You can find the list of available notifiers using the
 </div>
 </div>
 <div class="sect3">
-<h4 id="example-6">Examples</h4>
+<h4 id="example-6"><a class="anchor" href="#example-6"></a>Examples</h4>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -1238,7 +1430,7 @@ You can find the list of available notifiers using the
 restart the server, use the following command:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-log-notifier-configure
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-log-notifier-configure
     --enabled=true
     --dynamic=true</code></pre>
 </div>
@@ -1250,7 +1442,7 @@ restart the server, use the following command:</p>
 without having to restart the server, use the following command:</p>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-hipchat-notifier-configure
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-hipchat-notifier-configure
     --enabled=false
     --dynamic=true</code></pre>
 </div>
@@ -1262,7 +1454,7 @@ without having to restart the server, use the following command:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="get-healthcheck-configuration"><code>get-healthcheck-configuration</code></h2>
+<h2 id="get-healthcheck-configuration"><a class="anchor" href="#get-healthcheck-configuration"></a><code>get-healthcheck-configuration</code></h2>
 <div class="sectionbody">
 <div class="dlist">
 <dl>
@@ -1278,13 +1470,13 @@ and enabled notifiers.</p>
 </dl>
 </div>
 <div class="sect3">
-<h4 id="command-options-7">Command Options</h4>
+<h4 id="command-options-7"><a class="anchor" href="#command-options-7"></a>Command Options</h4>
 <div class="paragraph">
 <p>There are no options available.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="example-7">Example</h4>
+<h4 id="example-7"><a class="anchor" href="#example-7"></a>Example</h4>
 <div class="paragraph">
 <p>A sample output is as follows:</p>
 </div>
@@ -1325,8 +1517,11 @@ Command get-healthcheck-configuration executed successfully.</pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-02-04 10:56:08 CET
+Last updated 2019-02-04 15:49:15 CET
 </div>
 </div>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/highlight.min.js"></script>
+<script>hljs.initHighlighting()</script>
 </body>
 </html>

--- a/documentation/payara-server/health-check-service/asadmin-commands.html
+++ b/documentation/payara-server/health-check-service/asadmin-commands.html
@@ -1798,7 +1798,7 @@ applies the configuration change without needing a restart:</p>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>--noisy</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Sets the notifier to noisy (a.k.a verbose) or not noisy. A noisy notifier includes <code>FINE</code> log level in its output. If not set no change is applied to current setting.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Sets the notifier to noisy (a.k.a verbose) or not noisy. A noisy notifier includes more detailed logging information in the notifiers output.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">No</p></td>
 </tr>
@@ -2010,7 +2010,7 @@ Command get-healthcheck-configuration executed successfully.</pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-02-08 10:39:30 CET
+Last updated 2019-02-08 17:33:57 CET
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">

--- a/documentation/payara-server/health-check-service/asadmin-commands.html
+++ b/documentation/payara-server/health-check-service/asadmin-commands.html
@@ -528,7 +528,7 @@ to correctly configure the HealthCheck Service.</p>
 <i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
-Enabling or disabling the health check service in general implicitly also enables or disables the log notifier which is the default notifier. This behaviour is similar to the replaced <a href="#healthcheck-configure"><code>healthcheck-configure</code></a> command.
+Enabling or disabling the health check service implicitly also enables or disables the log notifier which is the default notifier. This behaviour is similar to the replaced <a href="#healthcheck-configure"><code>healthcheck-configure</code></a> command.
 </td>
 </tr>
 </table>
@@ -537,7 +537,7 @@ Enabling or disabling the health check service in general implicitly also enable
 <div class="sect3">
 <h4 id="example-8"><a class="anchor" href="#example-8"></a>Example</h4>
 <div class="paragraph">
-<p>The following example will enabled the Healthcheck service such that it will
+<p>The following example will enable the Healthcheck service such that it will
 only activate from the next time the server is restarted. It enables the log
 notifier and sets the historical trace store to retain 20 health checks.</p>
 </div>
@@ -664,7 +664,7 @@ command to enable or disable other available notifiers.
 <div class="sect3">
 <h4 id="example"><a class="anchor" href="#example"></a>Example</h4>
 <div class="paragraph">
-<p>The following example will enabled the Healthcheck service such that it will
+<p>The following example will enable the Healthcheck service such that it will
 only activate from the next time the server is restarted. It enables the log
 notifier and sets the historical trace store to retain 20 health checks.</p>
 </div>
@@ -1798,7 +1798,7 @@ applies the configuration change without needing a restart:</p>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>--noisy</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Sets the notfier to noisy or not noisy. If not set no change is applied to current setting.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Sets the notifier to noisy (a.k.a verbose) or not noisy. A noisy notifier includes <code>FINE</code> log level in its output. If not set no change is applied to current setting.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">No</p></td>
 </tr>
@@ -2010,7 +2010,7 @@ Command get-healthcheck-configuration executed successfully.</pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-02-05 13:42:15 CET
+Last updated 2019-02-08 10:39:30 CET
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">

--- a/documentation/payara-server/health-check-service/asadmin-commands.html
+++ b/documentation/payara-server/health-check-service/asadmin-commands.html
@@ -1,0 +1,1332 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.5">
+<title>HealthCheck Service Asadmin Command Reference</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Remove comment around @import statement below when using as a custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
+audio,canvas,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+[hidden],template{display:none}
+script{display:none!important}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:transparent}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
+input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.spread{width:100%}
+p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:none}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol,ul.no-bullet,ol.no-bullet{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.no-bullet{list-style:none}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite:before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7;font-weight:bold}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
+.clearfix:after,.float-group:after{clear:both}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+*:not(pre)>code.nobreak{word-wrap:normal}
+*:not(pre)>code.nowrap{white-space:nowrap}
+pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menu{color:rgba(0,0,0,.8)}
+b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
+b.button:before{content:"[";padding:0 3px 0 2px}
+b.button:after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
+#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
+#content{margin-top:1.25em}
+#content:before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
+#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span:before{content:"\00a0\2013\00a0"}
+#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark:before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber:after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
+@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+.sect1{padding-bottom:.625em}
+@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
+.sect1+.sect1{border-top:1px solid #efefed}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
+.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
+.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
+.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
+.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
+@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
+@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
+.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
+.listingblock:hover code[data-lang]:before{display:block}
+.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
+.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
+table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
+table.pyhltable td.code{padding-left:.75em;padding-right:0}
+pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
+pre.pygments .lineno{display:inline-block;margin-right:.25em}
+table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
+.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
+.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
+.quoteblock .quoteblock blockquote:before{display:none}
+.verseblock{margin:0 1em 1.25em 1em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
+.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
+.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
+table.tableblock{max-width:100%;border-collapse:separate}
+table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all th.tableblock,table.grid-all td.tableblock{border-width:0 1px 1px 0}
+table.grid-all tfoot>tr>th.tableblock,table.grid-all tfoot>tr>td.tableblock{border-width:1px 1px 0 0}
+table.grid-cols th.tableblock,table.grid-cols td.tableblock{border-width:0 1px 0 0}
+table.grid-all *>tr>.tableblock:last-child,table.grid-cols *>tr>.tableblock:last-child{border-right-width:0}
+table.grid-rows th.tableblock,table.grid-rows td.tableblock{border-width:0 0 1px 0}
+table.grid-all tbody>tr:last-child>th.tableblock,table.grid-all tbody>tr:last-child>td.tableblock,table.grid-all thead:last-child>tr>th.tableblock,table.grid-rows tbody>tr:last-child>th.tableblock,table.grid-rows tbody>tr:last-child>td.tableblock,table.grid-rows thead:last-child>tr>th.tableblock{border-bottom-width:0}
+table.grid-rows tfoot>tr>th.tableblock,table.grid-rows tfoot>tr>td.tableblock{border-width:1px 0 0 0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot{border-width:1px 0}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+td>div.verse{white-space:pre}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.unstyled,ol.unnumbered,ul.checklist,ul.none{list-style-type:none}
+ul.unstyled,ol.unnumbered,ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1em;font-size:.85em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{width:1em;position:relative;top:1px}
+ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
+ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
+ul.inline>li>*{display:block}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
+.colist>table tr>td:last-of-type{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
+.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background-color:#00fafa}
+.black{color:#000}
+.black-background{background-color:#000}
+.blue{color:#0000bf}
+.blue-background{background-color:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background-color:#fa00fa}
+.gray{color:#606060}
+.gray-background{background-color:#7d7d7d}
+.green{color:#006000}
+.green-background{background-color:#007d00}
+.lime{color:#00bf00}
+.lime-background{background-color:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background-color:#7d0000}
+.navy{color:#000060}
+.navy-background{background-color:#00007d}
+.olive{color:#606000}
+.olive-background{background-color:#7d7d00}
+.purple{color:#600060}
+.purple-background{background-color:#7d007d}
+.red{color:#bf0000}
+.red-background{background-color:#fa0000}
+.silver{color:#909090}
+.silver-background{background-color:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background-color:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background-color:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background-color:#fafa00}
+span.icon>.fa{cursor:default}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]:after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@media print{@page{margin:1.25cm .75cm}
+*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]:after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
+.sect1{padding-bottom:0!important}
+.sect1+.sect1{border:0!important}
+#header>h1:first-child{margin-top:1.25rem}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span:before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]:before{display:block}
+#footer{background:none!important;padding:0 .9375em}
+#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+</style>
+</head>
+<body id="healthcheck-service" class="article">
+<div id="header">
+<h1>HealthCheck Service Asadmin Command Reference</h1>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>The following is a detailed list of the administration commands that can be used
+to correctly configure the HealthCheck Service.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="healthcheck-configure"><code>healthcheck-configure</code></h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+<dd>
+<p><code>asadmin&gt; healthcheck-configure --enabled=true|false --dynamic=true|false --historicaltraceenabled --historicaltracestoresize=20</code></p>
+</dd>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>Enables and disables the HealthCheck service. Also allows configuration of the store of historical health checks.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options">Command Options</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 27.2727%;">
+<col style="width: 9.0909%;">
+<col style="width: 45.4545%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.091%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Option</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Mandatory</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--target</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The instance or cluster that will enable or disable its service</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">server</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--dynamic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to apply the changes directly to the server without a restart</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--enabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to enable or disable the service</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--notifierenabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether or not to enable the default notifier</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--historicaltraceenabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enables historic checks if present</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--historicaltracestoresize</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Sets the maximum number of health checks to store</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+</tbody>
+</table>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+Starting from release <em>4.1.1.171</em>, the <code>--notifierenabled</code> argument is
+used to enable or disable the <strong>Log Notifier</strong>, which is considered the <em>default</em>
+notifier. Use the
+<a href="#healthcheck-notifier-configure"><code>healthcheck-[NOTIFIER_NAME]-configure</code></a>
+command to enable or disable other available notifiers.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="example">Example</h4>
+<div class="paragraph">
+<p>The following example will enabled the Healthcheck service such that it will
+only activate from the next time the server is restarted. It enables the log
+notifier and sets the historical trace store to retain 20 health checks.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin &gt; healthcheck-configure
+    --enabled=true
+    --dynamic=false
+    --notifierenabled=true
+    --historicaltraceenabled=true
+    --historicaltracestoresize=20</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="healthcheck-list-services"><code>healthcheck-list-services</code></h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+<dd>
+<p><code>asadmin&gt; healthcheck-list-services</code></p>
+</dd>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>Lists the names of all available metric checker services.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options-1">Command Options</h4>
+<div class="paragraph">
+<p>There are no options available.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="example-1">Example</h4>
+<div class="paragraph">
+<p>Running the command will show output similar to the example below:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>Available Health Check Services:
+        healthcheck-cpool
+        healthcheck-cpu
+        healthcheck-gc
+        healthcheck-heap
+        healthcheck-threads
+        healthcheck-machinemem
+
+Command healthcheck-list-services executed successfully.</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="healthcheck-configure-service"><code>healthcheck-configure-service</code></h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+<dd>
+<p><code>asadmin&gt; healthcheck-configure-service --serviceName=&lt;service.name&gt;
+--checkerName=&lt;name&gt; --enabled=true|false --dynamic=true|false
+--time=&lt;integer.value&gt; --unit=MICROSECONDS|MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS</code></p>
+</dd>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>Enables or disables the monitoring of an specific checker. The command
+also configures the frequency of monitoring for that metric.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options-2">Command Options</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 23.0769%;">
+<col style="width: 7.6923%;">
+<col style="width: 38.4615%;">
+<col style="width: 23.0769%;">
+<col style="width: 7.6924%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Option</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Mandatory</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--target</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The instance or cluster that will enable or disable its metric configuration</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>server</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--dynamic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to apply the changes directly to the server/instance without a restart</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>false</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--enabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to enable or disable the metric monitoring</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>N/A</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--serviceName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The metric service name. Must correspond to one of the values listed before</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--checkerName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A user determined name for easy identification of the checker. This should be
+unique among the services you have configured, to avoid confusion on the
+notification messages.</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>Depends on the service checker. One of:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>CONP</code></p>
+</li>
+<li>
+<p><code>CPUC</code></p>
+</li>
+<li>
+<p><code>GBGC</code></p>
+</li>
+<li>
+<p><code>HEAP</code></p>
+</li>
+<li>
+<p><code>HOGT</code></p>
+</li>
+<li>
+<p><code>MEMM</code></p>
+</li>
+</ul>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--time</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The amount of time units that the service will use to periodically monitor the metric</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--unit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TimeUnit</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The time unit to set the frequency of the metric monitoring. Must correspond to a valid
+<a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeUnit.html"><code>java.util.concurrent.TimeUnit</code></a>
+value</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p><code>MINUTES</code></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+</tbody>
+</table>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+If this command gets executed before running the <code>healthcheck-configure</code>
+command, it will succeed and the configuration will be saved, but the HealthCheck
+service will not be enabled.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="example-2">Example</h4>
+<div class="paragraph">
+<p>A very basic example command to simply enable the GC checker and activate it without
+needing a restart would be as follows:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-configure-service --enabled=true
+      --serviceName=healthcheck-gc
+      --name=MYAPP-GC
+      --dynamic=true</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="healthcheck-configure-service-threshold"><code>healthcheck-configure-service-threshold</code></h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+<dd>
+<p><code>asadmin&gt; healthcheck-configure-service-threshold --serviceName=&lt;service.name&gt;
+--dynamic=true|false --thresholdCritical=90 --thresholdWarning=50 --thresholdGood=0</code></p>
+</dd>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>Configures <code>CRITICAL</code>, <code>WARNING</code> and <code>GOOD</code> threshold range values for a
+service checker. The <code>dynamic</code> attribute should be set to <code>true</code> in order to apply
+the changes directly.</p>
+<div class="paragraph">
+<p>This command only configures thresholds for the following checkers:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>CPU Usage</p>
+</li>
+<li>
+<p>Connection Pool</p>
+</li>
+<li>
+<p>Heap Memory Usage</p>
+</li>
+<li>
+<p>Machine Memory Usage</p>
+</li>
+</ul>
+</div>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options-3">Command Options</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 23.0769%;">
+<col style="width: 7.6923%;">
+<col style="width: 38.4615%;">
+<col style="width: 23.0769%;">
+<col style="width: 7.6924%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Option</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Mandatory</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--target</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The instance or cluster that will be configured</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>server</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--dynamic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to apply the changes directly to the server/instance without a restart</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>false</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--serviceName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The metric service name. Must correspond to one of the values listed before</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--thresholdCritical</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The threshold value that this metric must surpass to generate a <strong><code>CRITICAL</code></strong> event. A value between <em>WARNING VALUE</em> and <em>100</em> must be used</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>90</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--thresholdWarning</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The threshold value that this metric must surpass to generate a <strong><code>WARNING</code></strong> event. A value between <em>GOOD VALUE</em> and <em>CRITICAL VALUE</em> must be used</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>50</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--thresholdGood</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The threshold value that this metric must surpass to generate a <strong><code>GOOD</code></strong> event. A value between <em>0</em> and <em>WARNING VALUE</em> must be used</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>0</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+</tbody>
+</table>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+In order to execute this command for an specific metric, the
+<code>healthcheck-configure-service</code> command needs to be executed first.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="example-3">Example</h4>
+<div class="paragraph">
+<p>Monitoring the health of JDBC connection pools is a common need. In that
+scenario, it is very unlikely that on-the-fly configuration changes
+would be made, so a very high <code>CRITICAL</code> threshold can be set. Likewise,
+a nonzero <code>GOOD</code> threshold is needed because an empty or unused
+connection pool may not be healthy either.</p>
+</div>
+<div class="paragraph">
+<p>The following command would apply these settings to the connection pool
+checker:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-configure-service-threshold
+ --serviceName=healthcheck-cpool
+ --dynamic=true
+ --thresholdCritical=95
+ --thresholdWarning=70
+ --thresholdGood=30</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="healthcheck-hoggingthreads-configure"><code>healthcheck-hoggingthreads-configure</code></h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+<dd>
+<p><code>asadmin&gt; healthcheck-hoggingthreads-configure --dynamic=true|false --threshold-percentage=50 --retry-count=3</code></p>
+</dd>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>Configures the <strong>Hogging Threads</strong> checker service settings. The checker
+will determine which running threads are hogging the CPU by calculating a percentage
+of usage with the ratio of elapsed time to the checker service execution interval and
+verifying if this percentage exceeds the <code>threshold-percentage</code>.</p>
+<div class="paragraph">
+<p>You can also use this command to  enable the checker and configure the monitoring
+frequency as you would do with the <code>healthcheck-configure-service</code> command.</p>
+</div>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options-4">Command Options</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 23.0769%;">
+<col style="width: 7.6923%;">
+<col style="width: 38.4615%;">
+<col style="width: 23.0769%;">
+<col style="width: 7.6924%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Option</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Mandatory</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--target</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The instance or cluster that will be configured</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>server</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--enabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to enable or disable the checker</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>true</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--dynamic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to apply the changes directly to the server/instance without a restart</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>false</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--threshold-percentage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The threshold value that this metric will be compared to mark threads as hogging the CPU</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>95</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--retry-count</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The number of retries that the checker service will execute in order to identify a hogging thread</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>3</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--time</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The periodic amount of time units the checker service will use to monitor hogging threads</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>1</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--unit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TimeUnit</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The time unit to set the frequency of the metric monitoring. Must correspond to a valid <a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeUnit.html"><code>java.util.concurrent.TimeUnit</code></a> value</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p><code>SECONDS</code></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="example-4">Example</h4>
+<div class="paragraph">
+<p>Monitoring which threads hog the CPU is extremely important since this can lead
+to performance degradation, deadlocks and extreme bottlenecks issues that web
+applications can incur. In some cases the defaults are all that is needed, but imagine
+that in a critical system you want to set the threshold percentage to <strong>90%</strong>,
+and you want to make sure that the health check service guarantees the state of such
+threads with a retry count of <strong>5</strong>. Additionally, you want to set the frequency of
+this check for every <em>20 seconds</em>.</p>
+</div>
+<div class="paragraph">
+<p>The following command would apply these settings to the connection pool
+checker:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-hoggingthreads-configure
+ --dynamic=true
+ --threshold-percentage=90
+ --retry-count=5
+ --time=20
+ --unit=SECONDS</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="healthcheck-stuckthreads-configure"><code>healthcheck-stuckthreads-configure</code></h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+<dd>
+<p><code>asadmin&gt; healthcheck-stuckthreads-configure --enabled true|false --dynamic true|false
+--time=&lt;integer.value&gt; --unit=MICROSECONDS|MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS
+--threshold=&lt;integer.value&gt; --thresholdUnit=MICROSECONDS|MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS</code></p>
+</dd>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>Configures the Stuck Thread checker. The Stuck Threads checker is comparable to the request tracing service, in that it is triggered by exceeding a configured threshold. but in this case it reports on all threads that, when the healthcheck runs, have taken longer than the threshold time.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options-5">Command Options</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 23.0769%;">
+<col style="width: 7.6923%;">
+<col style="width: 38.4615%;">
+<col style="width: 23.0769%;">
+<col style="width: 7.6924%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Option</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Mandatory</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--enabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enables or disables the checker</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--dynamic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether or not to apply the changes dynamically (without a restart)</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>false</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--time</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The time between checks, must be 1 or greater</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--unit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeUnit.html"><code>TimeUnit</code></a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The unit for the time between healthchecks</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--threshold</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The threshold above which a thread is considered stuck. Must be 1 or greater.</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--thresholdUnit</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeUnit.html"><code>TimeUnit</code></a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The unit for the threshold for when a thread should be considered stuck</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--target</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The target to enable the checker on</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p><code>server</code> (the DAS)</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="example-5">Example</h4>
+<div class="paragraph">
+<p>The following example configures the stuckthreads checker to check every 30
+seconds for any threads which have been stuck for more than 5 minutes and
+applies the configuration change without needing a restart:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-Shell" data-lang="Shell">asadmin&gt; healthcheck-stuckthreads-configure
+    --enabled=true
+    --dynamic=true
+    --time=30
+    --unit=SECONDS
+    --threshold=5
+    --thresholdUnit=MINUTES</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="healthcheck-notifier-configure"><code>healthcheck-[NOTIFIER_NAME]-notifier-configure</code></h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+<dd>
+<p><code>asadmin&gt; healthcheck-[NOTIFIER_NAME]-notifier-configure --enabled=true --dynamic=true</code></p>
+</dd>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>This command can be used to enable or disable the notifier represented by
+the <em>[NOTIFIER_NAME]</em> placeholder.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options-6">Command Options</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Option</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Mandatory</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--enable</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enables or disables the notifier</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--dynamic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to apply the changes directly to the server/instance without a restart</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">No</p></td>
+</tr>
+</tbody>
+</table>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+You can find the list of available notifiers using the
+<a href="/documentation/payara-server/notification-service/asadmin-commands.adoc#notifier-list-services"><code>notifier-list-services</code></a> command.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="example-6">Examples</h4>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>To enable the log notifier for the HealthCheck Service without having to
+restart the server, use the following command:</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-log-notifier-configure
+    --enabled=true
+    --dynamic=true</code></pre>
+</div>
+</div>
+</li>
+<li>
+<p>To disable the
+<a href="/documentation/payara-server/notification-service/notifiers/hipchat-notifier.adoc">Hipchat notifier</a>
+without having to restart the server, use the following command:</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-shell" data-lang="shell">asadmin&gt; healthcheck-hipchat-notifier-configure
+    --enabled=false
+    --dynamic=true</code></pre>
+</div>
+</div>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="get-healthcheck-configuration"><code>get-healthcheck-configuration</code></h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+<dd>
+<p><code>asadmin&gt; get-healthcheck-configuration</code></p>
+</dd>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>Lists the current configuration for the health check service, configured checkers
+and enabled notifiers.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options-7">Command Options</h4>
+<div class="paragraph">
+<p>There are no options available.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="example-7">Example</h4>
+<div class="paragraph">
+<p>A sample output is as follows:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>Health Check Service Configuration is enabled?: true
+Historical Tracing Enabled?: false
+Name      Notifier Enabled
+XMPP      false
+DATADOG   true
+EMAIL     false
+SLACK     true
+EVENTBUS  false
+HIPCHAT   false
+NEWRELIC  true
+SNMP      false
+LOG       true
+JMS       false
+
+Below are the list of configuration details of each checker listed by its name.
+
+Name  Enabled  Time  Unit
+GBGC  true     2     MINUTES
+
+Name  Enabled  Time  Unit     Threshold Percentage  Retry Count
+HOGT  true     5     MINUTES  78                    5
+
+Name  Enabled  Time  Unit     Critical Threshold  Warning Threshold  Good Threshold
+CPUC  true     30    SECONDS  80                  50                 0
+HEAP  true     1     MINUTES  80                  50                 0
+
+Command get-healthcheck-configuration executed successfully.</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2019-02-04 10:56:08 CET
+</div>
+</div>
+</body>
+</html>

--- a/documentation/payara-server/health-check-service/asadmin-commands.html
+++ b/documentation/payara-server/health-check-service/asadmin-commands.html
@@ -441,9 +441,12 @@ to correctly configure the HealthCheck Service.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>set-healthcheck-configuration --enabled=true|false --dynamic=true|false
---trace-enabled=true|false --trace-store-size=20
---trace-store-timeout=&lt;integer.value&gt;s|m|h|d]</pre>
+<pre>set-healthcheck-configuration
+ --enabled=true|false
+ --dynamic=true|false
+ --historic-trace-enabled=true|false
+ --historic-trace-store-size=20
+ --historic-trace-store-timeout=&lt;integer.value&gt;s|m|h|d</pre>
 </div>
 </div>
 <div class="dlist">
@@ -455,7 +458,7 @@ to correctly configure the HealthCheck Service.</p>
 </dl>
 </div>
 <div class="sect3">
-<h4 id="command-options"><a class="anchor" href="#command-options"></a>Command Options</h4>
+<h4 id="command-options-8"><a class="anchor" href="#command-options-8"></a>Command Options</h4>
 <table class="tableblock frame-all grid-all spread">
 <colgroup>
 <col style="width: 27.2727%;">
@@ -496,30 +499,23 @@ to correctly configure the HealthCheck Service.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">yes</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--notifierenabled</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Whether or not to enable the default notifier</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--trace-enabled</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--historic-trace-enabled</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Enables historic checks if present</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--trace-store-size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--historic-trace-store-size</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Integer</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Sets the maximum number of health checks to store</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">20</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--trace-store-timeout</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--historic-trace-store-timeout</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Sets the time period after which a historic health check event entry is removed from visable history. The time expression should consist of a single number followed by a time unit, <code>s</code> for seconds, <code>m</code> for minutes, <code>h</code> for hours or <code>d</code> for days. If no time unit is given the number specifies seconds. If the parameter is zero or unspecified there is no timeout for entries.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Sets the time period after which a historic health check event entry is removed from visable history. The time expression should consist of a number followed by a time unit; <code>s</code> for seconds, <code>m</code> for minutes, <code>h</code> for hours or <code>d</code> for days. If no time unit is given the number specifies seconds. If the parameter is zero or unspecified there is no timeout for entries.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
 </tr>
@@ -550,8 +546,8 @@ notifier and sets the historical trace store to retain 20 health checks.</p>
 <pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; set-healthcheck-configuration
     --enabled=true
     --dynamic=false
-    --trace-enabled=true
-    --trace-store-size=20</code></pre>
+    --historic-trace-enabled=true
+    --historic-trace-store-size=20</code></pre>
 </div>
 </div>
 </div>
@@ -701,7 +697,7 @@ notifier and sets the historical trace store to retain 20 health checks.</p>
 </dl>
 </div>
 <div class="sect3">
-<h4 id="command-options-1"><a class="anchor" href="#command-options-1"></a>Command Options</h4>
+<h4 id="command-options-9"><a class="anchor" href="#command-options-9"></a>Command Options</h4>
 <div class="paragraph">
 <p>There are no options available.</p>
 </div>
@@ -792,16 +788,18 @@ Command healthcheck-list-services executed successfully.</pre>
 <div class="listingblock">
 <div class="content">
 <pre>set-healthcheck-service-configuration
-    --service=&lt;service.name&gt;
-    --enabled=true|false
-    --dynamic=true|false
-    --time=&lt;integer.value&gt;
-    --time-unit=MICROSECONDS|MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS
-    --threshold-critical=80 --threshold-warning=50 --threshold-good=0
-    --hogging-threads-threshold=&lt;integer.value&gt;
-    --hogging-threads-retry-count=&lt;integer.value&gt;
-    --stuck-threads-threshold=&lt;integer.value&gt;
-    --stuck-threads-threshold-unit=DAYS|HOURS|MICROSECONDS|MILLISECONDS|MINUTES|NANOSECONDS|SECONDS</pre>
+ --service=&lt;service.name&gt;
+ --enabled=true|false
+ --dynamic=true|false
+ --time=&lt;integer.value&gt;
+ --time-unit=DAYS|HOURS|MINUTES|SECONDS|MILLISECONDS
+ --threshold-critical=80
+ --threshold-warning=50
+ --threshold-good=0
+ --hogging-threads-threshold=&lt;integer.value&gt;
+ --hogging-threads-retry-count=&lt;integer.value&gt;
+ --stuck-threads-threshold=&lt;integer.value&gt;
+ --stuck-threads-threshold-unit=DAYS|HOURS|MINUTES|SECONDS|MILLISECONDS</pre>
 </div>
 </div>
 <div class="dlist">
@@ -814,7 +812,7 @@ also configures the frequency of monitoring for that metric. Furthermore it conf
 </dl>
 </div>
 <div class="sect3">
-<h4 id="truecommand-options"><a class="anchor" href="#truecommand-options"></a>Command Options</h4>
+<h4 id="command-options-10"><a class="anchor" href="#command-options-10"></a>Command Options</h4>
 <table class="tableblock frame-all grid-all spread">
 <colgroup>
 <col style="width: 23.0769%;">
@@ -1700,8 +1698,159 @@ applies the configuration change without needing a restart:</p>
 </div>
 </div>
 <div class="sect1">
+<h2 id="set-healthcheck-service-notifier-configuration"><a class="anchor" href="#set-healthcheck-service-notifier-configuration"></a><code>set-healthcheck-service-notifier-configuration</code></h2>
+<div class="sectionbody">
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Usage</strong></dt>
+</dl>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>asadmin&gt; set-healthcheck-service-notifier-configuration
+ --notifier=&lt;string.value&gt;
+ --enabled=true|false
+ --dynamic=true|false
+ --noisy=true|false</pre>
+</div>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>Aim</strong></dt>
+<dd>
+<p>This command can be used to enable or disable a specific notifier or to change its noisy setting.</p>
+</dd>
+</dl>
+</div>
+<div class="sect3">
+<h4 id="command-options-14"><a class="anchor" href="#command-options-14"></a>Command Options</h4>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Option</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Mandatory</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--notifier</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><div><div class="paragraph">
+<p>The notifier to configure. One of (case insensitive):</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>LOG</code></p>
+</li>
+<li>
+<p><code>HIPCHAT</code></p>
+</li>
+<li>
+<p><code>SLACK</code></p>
+</li>
+<li>
+<p><code>JMS</code></p>
+</li>
+<li>
+<p><code>EMAIL</code></p>
+</li>
+<li>
+<p><code>XMPP</code></p>
+</li>
+<li>
+<p><code>SNMP</code></p>
+</li>
+<li>
+<p><code>EVENTBUS</code></p>
+</li>
+<li>
+<p><code>NEWRELIC</code></p>
+</li>
+<li>
+<p><code>DATADOG</code></p>
+</li>
+<li>
+<p><code>CDIEVENTBUS</code></p>
+</li>
+</ul>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--enable</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Enables or disables the notifier</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Yes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--noisy</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Sets the notfier to noisy or not noisy. If not set no change is applied to current setting.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">No</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--dynamic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Whether to apply the changes directly to the server/instance without a restart</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">No</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>--target</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The instance or cluster that will be configured</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">server</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">no</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="example-14"><a class="anchor" href="#example-14"></a>Examples</h4>
+<div class="paragraph">
+<p>To enable the log notifier for the HealthCheck Service without having to
+restart the server, use the following command:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-shell" data-lang="shell">asadmin&gt; set-healthcheck-service-notifier-configuration
+ --notifier=log
+ --enabled=true
+ --dynamic=true</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
 <h2 id="healthcheck-notifier-configure"><a class="anchor" href="#healthcheck-notifier-configure"></a><code>healthcheck-[NOTIFIER_NAME]-notifier-configure</code></h2>
 <div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+This is deprecated in 5.191 and will be removed in the future as it is replaced with the <a href="#set-healthcheck-service-notifier-configuration"><code>set-healthcheck-service-notifier-configuration</code></a> command.
+</td>
+</tr>
+</table>
+</div>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>Usage</strong></dt>
@@ -1861,7 +2010,7 @@ Command get-healthcheck-configuration executed successfully.</pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-02-05 11:06:50 CET
+Last updated 2019-02-05 13:42:15 CET
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">


### PR DESCRIPTION
This adds the documentation changes for https://github.com/payara/Payara/pull/3663 and https://github.com/payara/Payara/pull/3679.

I used AsciidocFX to edit sources and generate the updated HTML.

In general 3 seconds on 3 new commands were added. These are meant to replace several commands in the future that I marked deprecated for now. I used the `INFO` tag for that at the very beginning of the deprecated commands as I found it used elsewhere in the documentation.

The difference to the replaced commands often is marginal. I did this slowly and careful so hopefully this pays off and I got the details correct and did not mix it up. The examples given are based on the examples given for the replaced commands and were adopted to the new commands. For the new commands I also documented some parameters that did exist before but were undocumented.