### PR TITLE
PAYARA-3817 Added upgrade instructions for JDK 11 domains

### DIFF
--- a/documentation/user-guides/upgrade-payara.adoc
+++ b/documentation/user-guides/upgrade-payara.adoc
@@ -133,6 +133,33 @@ You can also start nodes in the same way:
 /opt/payara/162/payara41/bin/asadmin start-local-instance --nodedir /opt/payara/nodes myLocalNode
 ----
 
+[[jdk-11-upgrade-considerations]]
+== JDK 11: Upgrade considerations
+
+From Payara Server 5.192 onwards `domain.xml` contains instructions for handling JDK 11. Without these instructions, Payara will not start up on JDK 11 and/or will throw many exceptions during runtime.
+
+If older, pre-5.192, domains are being migrated this has to be taken into account. The following `jvm-options` have to be added to the `java-config` element in `domain.xml`:
+
+```xml
+    <jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+    <jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>      
+    <jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+    <jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+    <jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+    <jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+    <jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+    <jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+    <jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+```
+
+The following `jvm-options` have to be  have to removed:
+
+```xml
+    <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
+    <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
+```
+
+Note that in Payara 5.192 support for JDK 11 is limited to a *_technical preview_*.
 
 ---
 [[see-also]]


### PR DESCRIPTION
PAYARA-3817 JDK 11 cc @rdebusscher 

Signed-off-by: arjantijms <arjan.tijms@gmail.com>