### PR TITLE
Revert removing ext and endorsed sys props

### DIFF
--- a/documentation/payara-server/production-ready-domain.adoc
+++ b/documentation/payara-server/production-ready-domain.adoc
@@ -5,7 +5,7 @@ _Since Payara Server 5.181_
 
 Payara Server comes with a default domain, `domain1`, which has been
 inherited from GlassFish. This domain (and its accompanying template)
-has not been significantly modified for Payara Server since its inheritance from GlassFish.
+has not been significantly modified for Payara Server since its inheritance from GlassFish. 
 The default domain is not however designed to be run in production, but instead to be
 a usable example for development and testing purposes.
 
@@ -119,10 +119,12 @@ The following JVM options appear in both `domain` and `production` domain:
 * `-Djdk.corba.allowOutputStreamSubclass=true`
 * `-Djavax.xml.accessExternalSchema=all`
 * `-XX:+UnlockDiagnosticVMOptions`
+* `-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed`
 * `-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy`
 * `-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf`
 * `-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks`
 * `-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks`
+* `-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext`
 * `-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver`
 * `-DANTLR_USE_DIRECT_CLASS_LOADING=true`
 * `-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory`
@@ -130,5 +132,4 @@ The following JVM options appear in both `domain` and `production` domain:
 * `-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false`
 * `-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager`
 
-Support for the `java.endorsed.dirs` and `java.ext.dirs` options are removed from version 5.192 onwards (these were deprecated since 5.191).
-The concept of endorsed and ext directories are no longer supported with Java 9+.
+Use of the `java.endorsed.dirs` and `java.ext.dirs` options is *deprecated* and will be removed in a future release, as will those `endorsed` and `ext` directories.

--- a/release-notes/release-notes-192.adoc
+++ b/release-notes/release-notes-192.adoc
@@ -30,15 +30,6 @@ preview) as our first iteration of better native Docker integration. These
 function similarly to existing nodes, except the instances created for a Docker
 node are run within Docker containers.
 
-=== Removal of System Property
-
-The system property `java.ext.dirs` is no longer supported. This also means that
-JAR files within the `<payara-home>/glassfish/domains/<domain>/lib/ext` directory are no longer placed on the classpath.
-The `<payara-home>/glassfish/domains/<domain>/lib` directory is the preferred place to put these additional JAR files or
-the `asadmin add-library` command can be used to place it there for you.
-
-Also the System property `java.endorsed.dirs` is no longer supported.
-
 == Known Issues
 
 - [PAYARA-3865] - Output of asadmin osgi commands is not displayed. The issue was discovered later in release cycle. Workaround is to use OSGi shell over


### PR DESCRIPTION
We've agreed that removing the sys props for JDK 8 was a mistake and it's a bug that will be fixed. See PAYARA-3931. 

Reverting #539