### PR TITLE
Update links to some broken versions

### DIFF
--- a/book.json
+++ b/book.json
@@ -30,15 +30,15 @@
 					"text": "5.182"
 				},
 				{
-					"value": "https://docs.payara.fish/v/5.181/",
+					"value": "https://docs.payara.fish/v/4cac5ebea42ef9a55c9aef3258088f34c1617604/",
 					"text": "5.181"
 				},
 				{
-					"value": "https://docs.payara.fish/v/181/",
+					"value": "https://docs.payara.fish/v/a35a97138983ef52e5ab0dc90305a364b35e641b/",
 					"text": "4.1.2.181"
 				},
 				{
-					"value": "https://docs.payara.fish/v/174/",
+					"value": "https://docs.payara.fish/v/785176be2bb635f58ed577a44b70fe69d2e638ad/",
 					"text": "174"
 				},
 				{


### PR DESCRIPTION
Because gitbook is quirky, it doesn't show some versions. We have problems to force it to update the versions so we link to exact commit for each version which seems to work.