### PR TITLE
Fix incorrect beanvalidation tck sum

### DIFF
--- a/jakartaee-certification/5.193/tck-results-full-5.193.1.adoc
+++ b/jakartaee-certification/5.193/tck-results-full-5.193.1.adoc
@@ -42,7 +42,7 @@ SHA-256:  `75e969a7a3b3c77332154a2008309aad821a923d8684139242048a7640762808`
 +
 See test results in section `beanvalidation`. +
 https://download.eclipse.org/jakartaee/bean-validation/2.0/beanvalidation-tck-dist-2.0.5.zip[beanvalidation-tck-dist-2.0.5.zip], 
-SHA-256: `ebab3232311439dfc93559ca0dfa8cc230f51ab221cdc0a4901a8533f129f3ad`
+SHA-256: `b6778914f78bfcce5d6934347d71502603b1b0a6bbfdfbcf956271c367d40974`
 ** Jakarta Batch 1.0 TCK tests are included in Jakarta EE 8 CTS tests, See test results in section `batch` 
 - Java runtime used to run the implementation:
 +


### PR DESCRIPTION
The provided sha256sum was incorrect, likely referring to previous artifact version.