### PR TITLE
Improvements for Lite Remote EJB Client Code

### DIFF
--- a/documentation/payara-server/ejb/lite-remote-ejb.adoc
+++ b/documentation/payara-server/ejb/lite-remote-ejb.adoc
@@ -108,7 +108,7 @@ public interface BeanRemote {
 }
 ----
 
-. Second, consider a (secured) EJB that implements that interface and resides in a EJB application called "test" deployed on a Payara server instance that is listening in `https://localhost:8080`:
+. Second, consider a (secured) EJB that implements that interface and resides in a EJB application called "test" deployed on a Payara server instance that is listening in `http://localhost:8080`:
 +
 [source, java]
 ----
@@ -132,28 +132,102 @@ public class Bean implements BeanRemote, Serializable {
 ----
 import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
 import static javax.naming.Context.PROVIDER_URL;
-import static javax.naming.Context.SECURITY_CREDENTIALS;
-import static javax.naming.Context.SECURITY_PRINCIPAL;
 
-import java.util.Hashtable;
+import java.util.Properties;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 
-Hashtable<String, String> environment = new Hashtable<String, String>();
-environment.put(INITIAL_CONTEXT_FACTORY, "fish.payara.ejb.rest.client.RemoteEJBContextFactory");
-environment.put(PROVIDER_URL, "https://localhost:8080/ejb-invoker");
-environment.put(SECURITY_PRINCIPAL, "u1");
-environment.put(SECURITY_CREDENTIALS, "p1");
+public class RemoteEJBLiteClient{
 
-InitialContext ejbRemoteContext = new InitialContext(environment);
+    public static void main(String... args) throws NamingException{
+        
+        Properties environment = new Properties();
+        environment.put(INITIAL_CONTEXT_FACTORY, "fish.payara.ejb.rest.client.RemoteEJBContextFactory");
+        environment.put(PROVIDER_URL, "http://localhost:8080/ejb-invoker");
 
-BeanRemote beanRemote = (BeanRemote) ejbRemoteContext.lookup("java:global/test/Bean");
-beanRemote.method() // returns "method"
+        InitialContext ejbRemoteContext = new InitialContext(environment);
+
+        BeanRemote beanRemote = (BeanRemote) ejbRemoteContext.lookup("java:global/test/Bean");
+        beanRemote.method() // returns "method"
+    }
+}
+----
+
+[[calling-secured-bean]]
+==== Calling a Secured Remote EJB
+
+When calling a secured EJB using the `ejb-invoker` endpoint, there are some considerations in place for the client code:
+
+. If the remote EJB is secured with transport confidentiality (and integrity) enabled like this:
++
+[source, xml]
+----
+<ejb>
+    <ejb-name>Bean</ejb-name>
+    <ior-security-config>
+        <transport-config>
+            <integrity>REQUIRED</integrity>
+            <confidentiality>REQUIRED</confidentiality>
+            <establish-trust-in-target>SUPPORTED</establish-trust-in-target>
+            <establish-trust-in-client>SUPPORTED</establish-trust-in-client>
+        </transport-config>
+    </ior-security-config>
+</ejb>
 ----
 +
-NOTE: If a remote bean is not secured, only the `INITIAL_CONTEXT_FACTORY` and `PROVIDER_URL` parameters are required.
+Then, the corresponding HTTP endpoint to use would be `https://localhost:8181/ejb-invoker` instead.
+
+. If the remote EJB also has authentication enabled (via username and password credentials) like this:
 +
-WARNING: When accessing secured EJBs you *should* use only HTTPS, as the submitted credentials will be transferred in clear text (not encrypted, only base64 encoded), which is a security risk you should avoid in any production environment.
+[source, xml]
+----
+<ejb>
+    <ejb-name>Bean</ejb-name>
+    <as-context>
+        <auth-method>USERNAME_PASSWORD</auth-method>
+        <realm>default</realm>
+        <required>true</required>
+    </as-context>
+</ejb>
+----
++
+Then the credentials required to correctly authenticate the user for the call have to be specified in the JNDI context with the following properties:
++
+* `javax.naming.Context.SECURITY_PRINCIPAL` for the username
+* `javax.naming.Context.SECURITY_CREDENTIALS` for the password
+
+Here's an example of the complete client code used to call a secured remote EJB:
+
+[source, java]
+----
+import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
+import static javax.naming.Context.PROVIDER_URL;
+import static javax.naming.Context.SECURITY_CREDENTIALS;
+import static javax.naming.Context.SECURITY_PRINCIPAL;
+
+import java.util.Properties;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+public class RemoteEJBLiteClient{
+
+    public static void main(String... args) throws NamingException{
+
+        Properties environment = new Properties();
+        environment.put(INITIAL_CONTEXT_FACTORY,"fish.payara.ejb.rest.client.RemoteEJBContextFactory");
+        environment.put(PROVIDER_URL, "https://localhost:8181/ejb-invoker");
+        environment.put(SECURITY_PRINCIPAL, "u1");
+        environment.put(SECURITY_CREDENTIALS, "p1");
+
+        InitialContext ejbRemoteContext = new InitialContext(environment);
+
+        BeanRemote beanRemote = (BeanRemote) ejbRemoteContext.lookup("java:global/test/Bean");
+        beanRemote.method() // returns "method"
+    }
+}
+----
+
+IMPORTANT: When accessing secured EJBs you *should* use only HTTPS (that means, enabling confidential transport requirements to the remote EJB), as the submitted credentials will be transferred in clear text (not encrypted, only base64 encoded), which is a security risk you should avoid in any production environment.
 
 [[jndi-customization-options]]
 === JNDI Customization Options


### PR DESCRIPTION
Clarifications were done on how to correctly call secured remote EJBs when using the `ejb-invoker` exposed by the Lite EJB client dependency.