### PR TITLE
[PAYARA-3263] - Corrected minor documentation issue

### DIFF
--- a/documentation/microprofile/opentracing.adoc
+++ b/documentation/microprofile/opentracing.adoc
@@ -50,4 +50,4 @@ Activating Request Tracing is done either via the admin console or using the com
 
 NOTE: All other options for request tracing are ignored as the created Spans are not processed within Payara.
 
-As an example, see https://github.com/payara/ecosystem-jaeger-tracing, which shows how to integrate a Jaeger client tracer. This can be added as a library to Payara with the command `add-library jaeger-tracer-lib`. Enabling request tracing in Payara Server is then required, which will then send traces from OpenTracing to a Jaeger collector on the same host.
+As an example, see https://github.com/payara/ecosystem-jaeger-tracing, which shows how to integrate a Jaeger client tracer. This can be added as a library to Payara with the command `add-library jaeger-tracer-lib-with-dependencies`. Enabling request tracing in Payara Server is then required, which will then send traces from OpenTracing to a Jaeger collector on the same host.


### PR DESCRIPTION
Documentation used to state that the default library jar should be added as a library to Payara in order to use an alternate OpenTracing implementation however doing so causes ClassDefNotFoundErrors - it is required that you use the jar-with-dependencies file from a maven build to deploy as a library