### PR TITLE
CUSTCOM-18 Add TLS 1.3 support when using Zulu JDK 8 [5.194]

### DIFF
--- a/documentation/payara-server/server-configuration/http/protocols.adoc
+++ b/documentation/payara-server/server-configuration/http/protocols.adoc
@@ -503,6 +503,26 @@ Whether to enable TLS V1.2 or not. Will be ignored if TLS is disabled.
 `set configs.config.server-config.network-config.protocols.protocol.${protocol-name}.ssl.tls12-enabled=[true/false]`
 
 ---
+[[configuration-ssl-tls13]]
+==== TLS V1.3 Enabled
+
+Whether to enable TLS V1.3 or not. Will be ignored if TLS is disabled.
+
+*Asadmin Command:*
+
+`set configs.config.server-config.network-config.protocols.protocol.${protocol-name}.ssl.tls13-enabled=[true/false]`
+
+NOTE: Support for TLS 1.3 is available with JDK 8 since 5.194 releases of Payara Platform but only when you are using 
+**Zulu JDK 1.8.0u222 or higher**. If you using a lower version than 1.8.0u222, checkbox to enable TLS 1.3 will not be visible on the 
+web administration console. 
+
+IMPORTANT: You will need to add the following Java Option:  **-Dfish.payara.clientHttpsProtocol=TLSv1.3** to the asadmin script for 
+TLS 1.3 to work with asadmin CLI. This sets the TLS version to 1.3 which will be used by the asadmin client. If you are using JDK 8, 
+you will also need to add the following Java Option: **-XX:+UseOpenJSSE**, this option makes OpenJSSE default TLS provider. OpenJSEE 
+is a JSEE provider created by Azul to support TLS 1.3 on JDK 8. See https://docs.azul.com/openjsse/index.htm[TLS 1.3 Support in Zulu 8 with OpenJSSE] 
+for more information.
+
+---
 [[configuration-ssl-client-auth]]
 ==== Client Authentication
 

--- a/documentation/payara-server/system-properties.adoc
+++ b/documentation/payara-server/system-properties.adoc
@@ -9,7 +9,7 @@ special behavior settings:
 | Option | Value Type | Description | Accepted Values | Default
 | fish.payara.clientHttpsProtocol | String | Sets the TLS version to be
 used by the asadmin client. This is separate from the TLS version set
-for HTTPS communication on a listener. | TLSv1, TLSv1.1, TLSv1.2 |TLSv1.2
+for HTTPS communication on a listener. | TLSv1, TLSv1.1, TLSv1.2, TLSv1.3 |TLSv1.2
 
 | fish.payara.classloading.delegate | Boolean | When set to false,
 libraries from applications, and


### PR DESCRIPTION
This has already been merged into the Master branch. https://github.com/payara/Payara-Server-Documentation/pull/679