### PR TITLE
CLOUD-41: Documentation on new switches and reuse of root directory

### DIFF
--- a/SUMMARY.adoc
+++ b/SUMMARY.adoc
@@ -179,6 +179,7 @@
 *** link:documentation/payara-server/docker/docker-nodes.adoc[Docker Nodes]
 *** link:documentation/payara-server/docker/docker-instances.adoc[Docker Instances]
 * link:documentation/payara-micro/payara-micro.adoc[Payara Micro Documentation]
+** link:documentation/payara-micro/rootdir.adoc[Root Configuration Directory]
 ** link:documentation/payara-micro/starting-instance.adoc[Starting an Instance]
 ** link:documentation/payara-micro/stopping-instance.adoc[Stopping an Instance]
 ** link:documentation/payara-micro/deploying/deploying.adoc[Deploying Applications]

--- a/documentation/payara-micro/adding-jars.adoc
+++ b/documentation/payara-micro/adding-jars.adoc
@@ -55,6 +55,9 @@ in the following example:
 java -jar payara-micro.jar --addLibs third-party.jar --addLibs /opt/application/jars --addLibs ~/v/mysql-jdbc-driver.jar
 ----
 
+This argument cannot be used when instance is started via <<starting.adoc#starting-an-instance-from-rootdir-launcher, root directory launcher>>. 
+It is however accepted when creating a launcher via `--outputlauncher` and provided libraries will be added to launcher's classpath.
+
 [[programmatically-using-api]]
 == Programmatically using the API
 

--- a/documentation/payara-micro/appendices/cmd-line-opts.adoc
+++ b/documentation/payara-micro/appendices/cmd-line-opts.adoc
@@ -107,6 +107,8 @@ than unpacking the runtime.| _false_
 |`--outputuberjar <file-path>`
 |Packages up an Uber JAR at the specified path based on the provided command
 line arguments and exit.|
+|`--outputlauncher`
+|Create launcher `launch-micro.jar` into the root directory that is specified by `--rootdir` and exit.|
 |`--port <http-port-number>`
 |Sets the HTTP port that the instance will bind to.| 8080
 |`--postbootcommandfile <file-path>`
@@ -116,7 +118,7 @@ line arguments and exit.|
 |`--prebootcommandfile <file-path>`
 |Provides a file of asadmin commands to run *before booting the server*.|
 |`--requesttracingadaptivesamplingtargetcount`|The target number of traces to sample per the configured time window | 6
-|`--requesttracingadaptivesamplingtimeunit`| The time unit for the adaptive sample time; a `java.util.concurrent.TimeUnit` value (also in singular) or one of the short forms: `ns`, `us`/`µs`, `ms`, `s`, `m`/`min`/`mins`, `h` or `d`.  | MINUTES
+|`--requesttracingadaptivesamplingtimeunit`| The time unit for the adaptive sample time; a `java.util.concurrent.TimeUnit` value (also in singular) or one of the short forms: `ns`, `us`/`Âµs`, `ms`, `s`, `m`/`min`/`mins`, `h` or `d`.  | MINUTES
 |`--requesttracingadaptivesamplingtimevalue`| The period of time to attempt to hit the adaptive sample target count in | 1
 |`--requesttracingthresholdunit <threshold-unit-notation>`
 |Sets the time unit for the requestTracingThresholdValue option, i.e. `SECONDS`,
@@ -142,4 +144,6 @@ and HTTPS is disabled.
 `java.io.tmpdir`.
 |`--version`
 |Displays the version information|
+|`--warmup`
+|Bootstrap the server and exit immediately|
 |=======================================================================

--- a/documentation/payara-micro/appendices/cmd-line-opts.adoc
+++ b/documentation/payara-micro/appendices/cmd-line-opts.adoc
@@ -145,5 +145,5 @@ and HTTPS is disabled.
 |`--version`
 |Displays the version information|
 |`--warmup`
-|Bootstrap the server and exit immediately|
+|Exit the server immediately after configuration is done, applications are deployed and it's ready to serve requests. |
 |=======================================================================

--- a/documentation/payara-micro/asadmin/pre-and-post-boot-scripts.adoc
+++ b/documentation/payara-micro/asadmin/pre-and-post-boot-scripts.adoc
@@ -77,10 +77,15 @@ image:/images/payara-micro/uber-jar-command-scripts-structure.png[Uber JAR Comma
 [[boot-scripts-with-persistent-rootdir]]
 == Boot Scripts with Persistent Root Directory
 
-The effects of boot scripts are applied to config directory after their link:/documentation/payara-server/server-configuration/var-substitution/usage-of-variables.adoc[variable references] are resolved.
+A command in a boot script usually results in change of configuration in `config/domain.xml`.
+When persistent root directory is reused between restarts, it may cause some commands to fail, particulary those that create new resources, like for example `create-jdbc-connection-pool`.
+However, failure of a script command is not critical for server startup, just a warning is logged in such case.
 
-When commands do not utilize variable references it is enough to apply boot scripts once, during <<../configuring/config-cmd-line.adoc#warmup, warmup run>>, sparing a bit of startup time.
-Conversely, when variable should be resolved on each startup, boot script arguments need to be passed to each invocation.
+By utilizing <<../configuring/config-cmd-line.adoc#warmup, warmup run>>, these commands can be run as part of preparation of root directory rather than run on every startup.
+That also spares startup time for productive instance.
+
+When command uses link:/documentation/payara-server/server-configuration/var-substitution/usage-of-variables.adoc[variable references], the values for variables are determined during execution of the script, before executing the command and changing the configuration.
+If variable value should be evaluated each time Payara Micro starts, then executing a script in `--warmup` will not suffice and the script needs to be passed as argument also for productive runs.
 
 [[restrictions-on-preboot-scripts]]
 == Restrictions on Preboot Scripts

--- a/documentation/payara-micro/asadmin/pre-and-post-boot-scripts.adoc
+++ b/documentation/payara-micro/asadmin/pre-and-post-boot-scripts.adoc
@@ -74,6 +74,14 @@ correctly:
 
 image:/images/payara-micro/uber-jar-command-scripts-structure.png[Uber JAR Command scripts structure]
 
+[[boot-scripts-with-persistent-rootdir]]
+== Boot Scripts with Persistent Root Directory
+
+The effects of boot scripts are applied to config directory after their link:/documentation/payara-server/server-configuration/var-substitution/usage-of-variables.adoc[variable references] are resolved.
+
+When commands do not utilize variable references it is enough to apply boot scripts once, during <<../configuring/config-cmd-line.adoc#warmup, warmup run>>, sparing a bit of startup time.
+Conversely, when variable should be resolved on each startup, boot script arguments need to be passed to each invocation.
+
 [[restrictions-on-preboot-scripts]]
 == Restrictions on Preboot Scripts
 

--- a/documentation/payara-micro/configuring/config-cmd-line.adoc
+++ b/documentation/payara-micro/configuring/config-cmd-line.adoc
@@ -3,7 +3,7 @@
 
 As described in
 link:/documentation/payara-micro/deploying/deploy-cmd-line.adoc[Deploying From the Command Line],
-the starting and configuration of an instance has to be done in its entirety on
+the starting and configuration of an instance can be done in its entirety on
 one line.
 
 The options available can be seen by running the JAR with the `--help` option,
@@ -25,6 +25,29 @@ As an example, see below for starting an instance with a non-default HTTP port:
 [source, java]
 ----
 java -jar payara-micro.jar --port 2468
+----
+
+[[warmup]]
+== Separating Configuration from Production Run
+
+An instance can be configured separately, but only when <<../rootdir.adoc#persistent, persistent root configuration directory>> is specified by means of command line argument `--rootDir`.
+
+When switch `--warmup` is supplied all configuration and deployment command line parameters are applied to configuration directory and the instance immediately shuts down:
+
+[source,java]
+----
+java -jar payara-micro.jar --option1 --option2 deployment.war --warmup
+----
+
+Another use case for --warmup is to collect profiling information for e. g. Class Data Sharing feature of JDK:
+
+[source,shell]
+----
+# Open JDK 11; launcher needs to be used because of simpler classpath
+java -XX:DumpLoadedClassList=classes.lst -jar rootidr/launch-micro.jar  --warmup
+
+# OpenJ9
+java -Xshareclasses:name=payara-micro -jar payara-micro.jar --warmup
 ----
 
 [[read-configuration-from-a-file]]

--- a/documentation/payara-micro/deploying/deploy-cmd-line.adoc
+++ b/documentation/payara-micro/deploying/deploy-cmd-line.adoc
@@ -21,8 +21,8 @@ java -jar payara-micro.jar --option1 --option2 ...
 [[persistent-rootdir]]
 == Using Persistent Configuration Directory
 
-When <<../rootdir.adoc#persistent-rootdir, persistent configuration directory>> is specified and is reused across restarts (i. e. not running in a container), it is not to specify deployment each time payara micro is invoked from that directory.
-Doing so  will cause the application to be deployed twice -- once at startup and second time when deployment section of command line is processed.
+When <<../rootdir.adoc#persistent-rootdir, persistent configuration directory>> is reused across restarts (i. e. not running in a container), it is recommended not to specify deployment each time Payara Micro is invoked from that directory.
+Doing so will cause the application to be deployed twice -- once at startup and second time when deployment section of the command line is processed.
 
 The best approach if your application uses persistent filesystem is to use warmup run for deployment:
 
@@ -31,7 +31,7 @@ The best approach if your application uses persistent filesystem is to use warmu
 # perform deployments and configuration
 java -jar payara-micro.jar --rootdir micro-root --warmup application.war
 
-# all further invocations do not use specify deployment
+# all further invocations do not specify deployment
 java -jar payara-micro.jar --rootdir micro-root
 ----
 

--- a/documentation/payara-micro/deploying/deploy-cmd-line.adoc
+++ b/documentation/payara-micro/deploying/deploy-cmd-line.adoc
@@ -8,9 +8,7 @@ Payara Micro supports deploying applications directly from the command line.
 
 As noted in the section
 link:/documentation/payara-micro/starting-instance.adoc#starting-an-instance-from-the-command-line[Starting an Instance],
-all Payara Micro actions are run for the Payara Micro JAR, all in one command;
-it is not possible to start an instance with one command, and deploy an application
-to it with another.
+all Payara Micro actions are run for the Payara Micro JAR, all in one command.
 
 The general structure of starting, configuring, and deploying an application to
 an instance is as follows:
@@ -20,20 +18,34 @@ an instance is as follows:
 java -jar payara-micro.jar --option1 --option2 ...
 ----
 
-== Define configuration directory
+[[persistent-rootdir]]
+== Using Persistent Configuration Directory
 
-Payara Micro creates a directory where it creates the equivalent of the Payara Server domain directory in order to run properly.
-With the command line parameter `--rootdir` one can specify the location of this directory.
+When <<../rootdir.adoc#persistent-rootdir, persistent configuration directory>> is specified and is reused across restarts (i. e. not running in a container), it is not to specify deployment each time payara micro is invoked from that directory.
+Doing so  will cause the application to be deployed twice -- once at startup and second time when deployment section of command line is processed.
 
-It is important to specify this value in production scenarios because the default value is in the temporary directory of the OS which can be cleaned by some processes.
-If this happens, the application will not behave correctly anymore.
+The best approach if your application uses persistent filesystem is to use warmup run for deployment:
 
-[source, shell]
+[source,shell]
 ----
-java -jar payara-micro.jar --rootdir <directory-path> --option2 ...
+# perform deployments and configuration
+java -jar payara-micro.jar --rootdir micro-root --warmup application.war
+
+# all further invocations do not use specify deployment
+java -jar payara-micro.jar --rootdir micro-root
 ----
 
-If the <directory-path> doesn't exist, it is created on the fly.
+Alternatively a launcher can be generated for configured root directory as well:
+
+[source,shell]
+----
+# perform deployments and configuration
+java -jar payara-micro.jar --rootdir micro-root --warmup application.war
+java -jar payara-micro.jar --rootdir micro-root --outputlauncher
+
+# all further invocations use parameterless launcher
+java -jar micro-root/launch-micro.jar
+----
 
 
 [[deploying-an-application-package]]
@@ -119,7 +131,6 @@ option multiple times:
 ----
 java -jar payara-micro.jar --deployFromGAV "fish.payara.examples,test,1.0-SNAPSHOT" --additionalRepository https://maven.java.net/content/repositories/promoted/ --additionalRepository https://raw.github.com/payara/Payara_PatchedProjects/master/
 ----
-
 
 [[define-context-root]]
 == Define context root

--- a/documentation/payara-micro/rootdir.adoc
+++ b/documentation/payara-micro/rootdir.adoc
@@ -1,0 +1,30 @@
+= Root Configuration Directory
+
+Payara Micro is distributed as single `.jar` file.
+However at runtime it creates and depends on folder structure that is refered to as Root Configuration Directory or `rootdir`.
+
+This directory stores all of instance configuration, deployed applications as well as implementation `.jar` files needed for running the instance.
+
+[[temp-rootdir]]
+== Temporary Root Configuration Directory
+
+By default, Payara Micro will create a folder in system's temporary directory and prepares root configuration directory there.
+This makes instances' configuration stateless, but also has to potentially undesireable effects:
+
+* Temporary directory may be deleted by system cleanup procedure. 
+  It is therefore important not to use temporary directory in production scenarios.
+  If files are removed by third party, the application will not behave correctly anymore.
+* Preparing the directory has impact on startup time
+
+[[persistent-rootdir]]
+== Persistent Root Configuration Directory
+
+Root configuration directory can be explicitly specified with command line parameter `--rootDir <directory>`.
+In such case the directory is created only once, and instance configuration is preserved across restarts of the instance.
+
+Following configuration is preserved:
+
+* Deployed applications
+* _effects_ of preboot, postboot and postdeploy commands
+* Logging configuration
+

--- a/documentation/payara-micro/rootdir.adoc
+++ b/documentation/payara-micro/rootdir.adoc
@@ -1,30 +1,29 @@
 = Root Configuration Directory
 
-Payara Micro is distributed as single `.jar` file.
-However at runtime it creates and depends on folder structure that is refered to as Root Configuration Directory or `rootdir`.
+Payara Micro is distributed as a single `.jar` file.
+However, at runtime, it creates and depends on a folder structure that is referred to as Root Configuration Directory or `rootdir`.
 
-This directory stores all of instance configuration, deployed applications as well as implementation `.jar` files needed for running the instance.
+This directory stores all of the instance configuration, deployed applications, as well as implementation `.jar` files needed for running the instance.
 
 [[temp-rootdir]]
 == Temporary Root Configuration Directory
 
-By default, Payara Micro will create a folder in system's temporary directory and prepares root configuration directory there.
-This makes instances' configuration stateless, but also has to potentially undesireable effects:
+By default, Payara Micro will create a folder in the system's temporary directory and prepares a root configuration directory there.
+This makes instances' configuration stateless, but also has two potentially undesirable effects:
 
 * Temporary directory may be deleted by system cleanup procedure. 
-  It is therefore important not to use temporary directory in production scenarios.
-  If files are removed by third party, the application will not behave correctly anymore.
-* Preparing the directory has impact on startup time
+  It is therefore important not to use a temporary directory in production scenarios.
+  If files are removed by a third party process, the application will not behave correctly anymore.
+* Preparing the directory has an impact on startup time
 
 [[persistent-rootdir]]
 == Persistent Root Configuration Directory
 
-Root configuration directory can be explicitly specified with command line parameter `--rootDir <directory>`.
-In such case the directory is created only once, and instance configuration is preserved across restarts of the instance.
+Root configuration directory can be explicitly specified with the command line parameter `--rootDir <directory>`.
+In such case, the directory is created only once, and instance configuration is preserved across restarts of the instance.
 
 Following configuration is preserved:
 
 * Deployed applications
-* _effects_ of preboot, postboot and postdeploy commands
+* Effects of preboot, postboot and postdeploy commands
 * Logging configuration
-

--- a/documentation/payara-micro/starting-instance.adoc
+++ b/documentation/payara-micro/starting-instance.adoc
@@ -34,7 +34,7 @@ After that, it is possible to launch payara with plain
 java -jar $rootDirectory/launch-micro.jar
 ----
 
-This makes configuration directory self-sufficient and the distribution file is no longer needed.
+This makes configuration directory self-sufficient and the distribution file (`payara-micro.jar`) is no longer needed.
 
 [[starting-an-instance-programmatically]]
 == Starting an Instance Programmatically

--- a/documentation/payara-micro/starting-instance.adoc
+++ b/documentation/payara-micro/starting-instance.adoc
@@ -16,6 +16,26 @@ java -jar payara-micro.jar
 This single command is all you need to run Payara Micro instances; additional
 configuration options are all part of this command.
 
+[[starting-an-instance-from-rootdir-launcher]]
+== Starting an Instance from Persistent Configuration Directory
+
+When using <<rootdir.adoc#persistent-rootdir, persistent root configuration directory>>, it is possible to generate a launcher bound to that directory using the command:
+
+[source,shell]
+----
+java -jar payara-micro.jar --outputlauncher --rootdir $rootDirectory
+----
+
+This will create file `$rootDirectory/launch-micro.jar` and exit immediately.
+After that, it is possible to launch payara with plain
+
+[source,shell]
+----
+java -jar $rootDirectory/launch-micro.jar
+----
+
+This makes configuration directory self-sufficient and the distribution file is no longer needed.
+
 [[starting-an-instance-programmatically]]
 == Starting an Instance Programmatically
 

--- a/documentation/payara-micro/stopping-instance.adoc
+++ b/documentation/payara-micro/stopping-instance.adoc
@@ -10,6 +10,8 @@ Payara Micro instances can be stopped by either:
 
 * Using `CTRL-C` on the terminal in which Payara Micro is running.
 * Sending a kill signal to the process ID of Payara Micro
+* Passing command-line switch `--warmup` will cause the instance to stop immediately after it bootstraps and deploys the applications.
+  This is useful for applying configuration to configuration root directory before productive use.
 
 [[stopping-an-instance-programmatically]]
 == Stopping an Instance Programmatically
@@ -47,7 +49,7 @@ import fish.payara.micro.BootstrapException;
 import fish.payara.micro.PayaraMicroRuntime;
 
 public class EmbeddedPayara{
-    public static void main(String[] args) throws BootstrapException{
+    public static void main(String[] args) throws BootstrapException {
 
         PayaraMicroRuntime instance = PayaraMicro.bootstrap();
         instance.shutdown();


### PR DESCRIPTION
I ended up documented consequences of reusing root directory much more than the new switches `--outputlauncher` and `--warmup`.